### PR TITLE
Support declarative pipeline syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can mock built-in Jenkins commands, job configurations, see the stacktrace o
 # Table of Contents
 1. [Usage](#usage)
 1. [Configuration](#configuration)
+1. [Declarative Pipeline](#declarative-pipeline)
 1. [Testing Shared Libraries](#testing-shared-libraries)
 1. [Note On CPS](#note-on-cps)
 1. [Contributing](#contributing)
@@ -311,6 +312,49 @@ This will work fine for such a project structure:
          └── groovy
              └── TestExampleJob.groovy
 ```
+## Declarative Pipeline
+There is an experimental support of declarative pipeline.
+To try this feature you need to use `DeclarativePipelineTest` class instead of `BasePipelineTest`
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent none
+    stages {
+        stage('Example Build') {
+            agent { docker 'maven:3-alpine' }
+            steps {
+                echo 'Hello, Maven'
+                sh 'mvn --version'
+            }
+        }
+        stage('Example Test') {
+            agent { docker 'openjdk:8-jre' }
+            steps {
+                echo 'Hello, JDK'
+                sh 'java -version'
+            }
+        }
+    }
+}
+```
+
+```groovy
+import com.lesfurets.jenkins.unit.declarative
+
+class TestExampleDeclarativeJob extends DeclarativePipelineTest {
+        @Test
+        void should_execute_without_errors() throws Exception {
+            def script = runScript("Jenkinsfile")
+            assertJobStatusSuccess()
+            printCallStack()
+        }
+}
+```
+
+### DeclarativePipelineTest
+It extends `BasePipelineTest` functionality so you can verify your decalrative job the same way
+like it was a scripted pipeline
 
 ## Testing Shared Libraries
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can mock built-in Jenkins commands, job configurations, see the stacktrace o
 
 ### Add to your project as test dependency
 
-Maven: 
+Maven:
 
 ```xml
     <dependency>
@@ -49,7 +49,7 @@ You can write your tests in Groovy or Java 8, using the test framework you prefe
 The easiest entry point is extending the abstract class `BasePipelineTest`, which initializes the framework with JUnit.
 
 Let's say you wrote this awesome pipeline script, which builds and tests your project :
- 
+
  ```groovy
 def execute() {
     node() {
@@ -83,9 +83,9 @@ Now using the Jenkins Pipeline Unit you can unit test if it does the job :
 import com.lesfurets.jenkins.unit.BasePipelineTest
 
 class TestExampleJob extends BasePipelineTest {
-        
+
         //...
-        
+
         @Test
         void should_execute_without_errors() throws Exception {
             def script = loadScript("job/exampleJob.jenkins")
@@ -126,7 +126,7 @@ You can define both environment variables and job execution parameters.
     @Before
     void setUp() throws Exception {
         super.setUp()
-        // Assigns false to a job parameter ENABLE_TEST_STAGE 
+        // Assigns false to a job parameter ENABLE_TEST_STAGE
         binding.setVariable('ENABLE_TEST_STAGE', 'false')
         // Defines the previous execution status
         binding.getVariable('currentBuild').previousBuild = [result: 'UNSTABLE']
@@ -134,7 +134,7 @@ You can define both environment variables and job execution parameters.
 ```
 
 The test helper already provides basic variables such as a very simple currentBuild definition.
-You can redefine them as you wish. 
+You can redefine them as you wish.
 
 ### Mock Jenkins commands
 
@@ -157,8 +157,8 @@ You can register interceptors to mock pipeline methods, including Jenkins comman
     }
 ```
 
-The test helper already includes some mocks, but the list is far from complete. 
-You need to _register allowed methods_ if you want to override these mocks and add others. 
+The test helper already includes some mocks, but the list is far from complete.
+You need to _register allowed methods_ if you want to override these mocks and add others.
 Note that you need to provide a method signature and a callback (closure or lambda) in order to allow a method.
 Any method call which is not recognized will throw an exception.
 
@@ -186,7 +186,7 @@ void should_execute_without_errors() throws Exception {
 
 ```
 
-This will check as well `mvn verify` has been called during the job execution. 
+This will check as well `mvn verify` has been called during the job execution.
 
 
 ### Check Pipeline status
@@ -206,9 +206,9 @@ To verify your pipeline is failing you need to check the status with `BasePipeli
 class TestCase extends BasePipelineTest {
   @Test
   void check_build_status() throws Exception {
-      helper.registerAllowedMethod("sh", [String.class], {cmd-> 
+      helper.registerAllowedMethod("sh", [String.class], {cmd->
           // cmd.contains is helpful to filter sh call which should fail the pipeline
-          if (cmd.contains("make")) { 
+          if (cmd.contains("make")) {
               binding.getVariable('currentBuild').result = 'FAILURE'
           }
       })
@@ -270,7 +270,7 @@ You then can go ahead and commit this change in your SCM to check in the change.
 
 ## Configuration
 
-The abstract class `BasePipelineTest` configures the helper with useful conventions: 
+The abstract class `BasePipelineTest` configures the helper with useful conventions:
 
 - It looks for pipeline scripts in your project in root (`./.`) and `src/main/jenkins` paths.
 - Jenkins pipelines let you load other scripts from a parent script with `load` command.
@@ -294,7 +294,7 @@ class TestExampleJob extends BasePipelineTest {
         scriptExtension = 'pipeline'
         super.setUp()
     }
-    
+
 }
 
 ```
@@ -314,12 +314,12 @@ This will work fine for such a project structure:
 
 ## Testing Shared Libraries
 
-With [Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/) Jenkins lets you share common code 
+With [Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/) Jenkins lets you share common code
 on pipelines across different repositories of your organization.
-Shared libraries are configured via a settings interface in Jenkins and imported 
+Shared libraries are configured via a settings interface in Jenkins and imported
 with `@Library` annotation in your scripts.
 
-Testing pipeline scripts using external libraries is not trivial because the shared library code 
+Testing pipeline scripts using external libraries is not trivial because the shared library code
 is checked in another repository.
 JenkinsPipelineUnit lets you test shared libraries and pipelines depending on these libraries.
 
@@ -361,23 +361,23 @@ Now let's test it:
                     .implicit(false)
                     .build()
     helper.registerSharedLibrary(library)
-    
+
     runScript("job/library/exampleJob.jenkins")
     printCallStack()
 ```
 
 Notice how we defined the shared library and registered it to the helper.
-Library definition is done via a fluent API which lets you set the same configurations as in 
+Library definition is done via a fluent API which lets you set the same configurations as in
 [Jenkins Global Pipeline Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries).
 
 The `retriever` and `targetPath` fields tell the framework how to fetch the sources of the library, in which local path.
 The framework comes with two naive but useful retrievers, `gitSource` and `localSource`.
 You can write your own retriever by implementing the `SourceRetriever` interface.
 
-Note that properties `defaultVersion`, `allowOverride` and `implicit` are optional with 
+Note that properties `defaultVersion`, `allowOverride` and `implicit` are optional with
 default values `master`, `true` and `false`.
 
-Now if we execute this test, the framework will fetch the sources from the Git repository and 
+Now if we execute this test, the framework will fetch the sources from the Git repository and
 load classes, scripts, global variables and resources found in the library.
 The callstack of this execution will look like the following:
 
@@ -445,18 +445,18 @@ If you already fiddled with Jenkins pipeline DSL, you experienced strange errors
 This is because Jenkins does not directly execute your pipeline in Groovy,
 but transforms the pipeline code into an intermediate format in order to run Groovy code in
 [Continuation Passing Style](https://en.wikipedia.org/wiki/Continuation-passing_style) (CPS).
- 
-The usual errors are partly due to the 
-[the sandboxing Jenkins applies](https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin#ScriptSecurityPlugin-GroovySandboxing) 
+
+The usual errors are partly due to the
+[the sandboxing Jenkins applies](https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin#ScriptSecurityPlugin-GroovySandboxing)
 for security reasons, and partly due to the
 [serializability Jenkins imposes](https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md#serializing-local-variables).
 
 Jenkins requires that at each execution step, the whole script context is serializable, in order to stop and resume the job execution.
-To simulate this aspect, CPS versions of the helpers transform your scripts into the CPS format and check if at each step your script context is serializable. 
+To simulate this aspect, CPS versions of the helpers transform your scripts into the CPS format and check if at each step your script context is serializable.
 
 To use this _*experimental*_ feature, you can use the abstract class `BasePipelineTestCPS` instead of `BasePipelineTest`.
 You may see some changes in the call stacks that the helper registers.
-Note also that the serialization used to test is not the same as what Jenkins uses. 
+Note also that the serialization used to test is not the same as what Jenkins uses.
 You may find some incoherence in that level.
 
 ## Contributing

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -1,6 +1,11 @@
 package com.lesfurets.jenkins.unit
 
+import static java.util.stream.Collectors.joining
 import static org.assertj.core.api.Assertions.assertThat
+
+import org.assertj.core.api.AbstractCharSequenceAssert
+
+import groovy.transform.Memoized
 
 abstract class BasePipelineTest {
 
@@ -175,11 +180,16 @@ abstract class BasePipelineTest {
         return helper.runScript(script)
     }
 
+    @Memoized
+    String callStackDump() {
+        return helper.callStack.stream()
+                     .map { it -> it.toString() }
+                     .collect(joining('\n'))
+    }
+
     void printCallStack() {
         if (!Boolean.parseBoolean(System.getProperty("printstack.disabled"))) {
-            helper.callStack.each {
-                println it
-            }
+            println callStackDump()
         }
     }
 
@@ -212,6 +222,14 @@ abstract class BasePipelineTest {
 
     private assertJobStatus(String status) {
         assertThat(binding.getVariable('currentBuild').result).isEqualTo(status)
+    }
+
+    AbstractCharSequenceAssert assertCallStack() {
+        return assertThat(callStackDump())
+    }
+
+    void assertCallStackContains(String text) {
+        assertCallStack().contains(text)
     }
 
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -67,7 +67,12 @@ abstract class BasePipelineTest {
     }
 
     void registerAllowedMethods() {
-        helper.registerAllowedMethod("build", [Map.class], null)
+        helper.registerAllowedMethod("build", [Map.class], {
+            [
+                getNumber:{100500},
+                getDescription:{"Dummy build description"}
+            ]
+        })
         helper.registerAllowedMethod("cron", [String.class], null)
         helper.registerAllowedMethod("ws", [String.class, Closure.class], null)
         helper.registerAllowedMethod("addShortText", [Map.class], null)
@@ -233,4 +238,40 @@ abstract class BasePipelineTest {
         assertCallStack().contains(text)
     }
 
+
+    /**
+     * Helper for adding a params value in tests
+     */
+    void addParam(String name, Object val, Boolean overWrite = false) {
+        Map params = binding.getVariable('params') as Map
+        if (params == null) {
+            params = [:]
+            binding.setVariable('params', params)
+        }
+        if (params[name] == null || overWrite) {
+            params[name] = val
+        }
+    }
+
+
+    /**
+     * Helper for adding a environment value in tests
+     */
+    void addEnvVar(String name, String val) {
+        Map env = binding.getVariable('env') as Map
+        if (env == null) {
+            env = [:]
+            binding.setVariable('env', env)
+        }
+        env[name] = val
+    }
+
+    void addCredential(String key, String val) {
+        Map credentials = binding.getVariable('credentials') as Map
+        if (credentials == null) {
+            credentials = [:]
+            binding.setVariable('credentials', credentials)
+        }
+        credentials[key] = val
+    }
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -136,6 +136,7 @@ abstract class BasePipelineTest {
             timeInMillis: 1,
             upstreamBuilds: [],
         ])
+        binding.setVariable('env',[:])
     }
 
     /**

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -1,0 +1,93 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
+
+import groovy.transform.Memoized
+import groovy.transform.ToString
+
+class AgentDeclaration {
+
+    String label
+    DockerDeclaration docker
+    Boolean dockerfile = null
+    String dockerfileDir
+    Boolean reuseNode = null
+    String customWorkspace
+
+    def label(String label) {
+        this.label = label
+    }
+
+    def node(Closure closure) {
+        closure.call()
+    }
+
+    def customWorkspace(String workspace) {
+        this.customWorkspace = workspace
+    }
+
+    def reuseNode(boolean reuse) {
+        this.reuseNode = reuse
+    }
+
+    def docker(String image) {
+        this.docker = new DockerDeclaration().with { it.image = image; it }
+    }
+
+    def docker(Closure closure) {
+        def dockerDeclaration = new DockerDeclaration()
+        def cl = closure.rehydrate(dockerDeclaration, this, this)
+        cl.resolveStrategy = Closure.DELEGATE_ONLY
+        cl.call()
+        this.docker = dockerDeclaration
+
+    }
+
+    def dockerfile(boolean dockerfile) {
+        this.dockerfile = dockerfile
+    }
+
+    def dockerfile(Closure closure) {
+        closure.call()
+    }
+
+    def dir(String dir) {
+        this.dockerfileDir = dir
+    }
+
+    def execute(Object delegate) {
+        def agentDesc = null
+        if (!label && !docker && dockerfile == null) {
+            throw new IllegalStateException("No agent description found")
+        }
+        agentDesc = printNonNullProperties(this)
+        Closure cl = { echo "Executing on agent $agentDesc" }
+        cl.rehydrate(delegate, this, this).call()
+    }
+
+    @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
+    class DockerDeclaration {
+
+        String image
+        String label
+        String args
+
+        def image(String image) {
+            this.image = image
+        }
+
+        def label(String label) {
+            this.label = label
+        }
+
+        def args(String args) {
+            this.args = args
+        }
+
+        @Memoized
+        String toString() {
+            return printNonNullProperties(this)
+        }
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipeline.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipeline.groovy
@@ -1,0 +1,80 @@
+package com.lesfurets.jenkins.unit.declarative
+
+class DeclarativePipeline extends GenericPipelineDeclaration {
+
+    def properties = [:]
+    List<Closure> options = []
+    Map<String, StageDeclaration> stages = [:]
+
+    Closure triggers
+    Closure parameters
+
+    static executeOn(Closure closure, Object delegate) {
+        if (closure) {
+            def cl = closure.rehydrate(delegate, this, this)
+            cl.resolveStrategy = Closure.DELEGATE_ONLY
+            cl.call()
+        }
+    }
+
+    static <T> T createComponent(Class<T> componentType, Closure closure) {
+        def componentInstance = componentType.newInstance()
+        def rehydrate = closure.rehydrate(componentInstance, this, this)
+        rehydrate.resolveStrategy = Closure.DELEGATE_ONLY
+        rehydrate.call()
+        return  componentInstance
+    }
+
+    DeclarativePipeline() {
+        properties.put('any', 'any')
+        properties.put('none', 'none')
+        properties.put('scm', 'scm')
+    }
+
+    def propertyMissing(String name) {
+        if (properties.containsKey(name)) {
+            return properties.get(name)
+        } else {
+            throw new IllegalStateException("Missing $name")
+        }
+    }
+
+    def propertyMissing(String name, arg) {
+
+    }
+
+    def options(Closure closure) {
+        options.add(closure)
+    }
+
+    def stages(Closure closure) {
+        closure.call()
+    }
+
+    def triggers(Closure closure) {
+        this.triggers = closure
+    }
+
+    def parameters(Closure closure) {
+        this.parameters = closure
+    }
+
+    def stage(String name, Closure closure) {
+        this.stages.put(name, createComponent(StageDeclaration, closure).with { it.name = name; it })
+    }
+
+    def execute(Object delegate) {
+        super.execute(delegate)
+        this.options.forEach {
+            executeOn(it, delegate)
+        }
+        this.agent?.execute(delegate)
+        executeOn(this.parameters, delegate)
+        executeOn(this.triggers, delegate)
+        this.stages.entrySet().forEach { e ->
+            e.value.execute(delegate)
+        }
+        this.post?.execute(delegate)
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
@@ -29,6 +29,9 @@ abstract class DeclarativePipelineTest extends BasePipelineTest {
         helper.registerAllowedMethod('pollSCM', [String.class], null)
         helper.registerAllowedMethod('cron', [String.class], null)
         helper.registerAllowedMethod('timestamps', [], null)
+
+        helper.registerAllowedMethod('skipDefaultCheckout', [], null)
+
         helper.registerAllowedMethod('script', [Closure.class], null)
 
         helper.registerAllowedMethod('timeout', [Integer.class, Closure.class], null)
@@ -68,42 +71,5 @@ abstract class DeclarativePipelineTest extends BasePipelineTest {
         helper.registerAllowedMethod('credentials', [String], { String credName ->
             return binding.getVariable('credentials')[credName]
         })
-
-    }
-
-    /**
-     * Helper for adding a params value in tests
-     */
-    void addParam(String name, Object val, Boolean overWrite = false) {
-        Map params = binding.getVariable('params') as Map
-        if (params == null) {
-            params = [:]
-            binding.setVariable('params', params)
-        }
-        if (params[name] == null || overWrite) {
-            params[name] = val
-        }
-    }
-
-
-    /**
-     * Helper for adding a environment value in tests
-     */
-    void addEnvVar(String name, String val) {
-        Map env = binding.getVariable('env') as Map
-        if (env == null) {
-            env = [:]
-            binding.setVariable('env', env)
-        }
-        env[name] = val
-    }
-
-    void addCredential(String key, String val) {
-        Map credentials = binding.getVariable('credentials') as Map
-        if (credentials == null) {
-            credentials = [:]
-            binding.setVariable('credentials', credentials)
-        }
-        credentials[key] = val
     }
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
@@ -1,0 +1,109 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static com.lesfurets.jenkins.unit.MethodSignature.method
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+
+abstract class DeclarativePipelineTest extends BasePipelineTest {
+
+    def pipelineInterceptor = { Closure closure ->
+        DeclarativePipeline.createComponent(DeclarativePipeline, closure).execute(delegate)
+    }
+
+    def paramInterceptor = { Map desc ->
+        addParam(desc.name, desc.defaultValue, false)
+    }
+
+    @Override
+    void setUp() throws Exception {
+        super.setUp()
+
+        /**
+         * Job params - may need to override in specific tests
+         */
+        binding.setVariable('params', [:])
+        binding.setVariable('credentials', [:])
+
+        helper.registerAllowedMethod(method("pipeline", Closure), pipelineInterceptor)
+
+        helper.registerAllowedMethod('pollSCM', [String.class], null)
+        helper.registerAllowedMethod('cron', [String.class], null)
+        helper.registerAllowedMethod('timestamps', [], null)
+        helper.registerAllowedMethod('script', [Closure.class], null)
+
+        helper.registerAllowedMethod('timeout', [Integer.class, Closure.class], null)
+
+        helper.registerAllowedMethod('waitUntil', [Closure.class], null)
+        helper.registerAllowedMethod('writeFile', [Map.class], null)
+        helper.registerAllowedMethod('build', [Map.class], null)
+        helper.registerAllowedMethod('tool', [Map.class], { t -> "${t.name}_HOME" })
+
+        helper.registerAllowedMethod('withCredentials', [Map.class, Closure.class], null)
+        helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], null)
+        helper.registerAllowedMethod('usernamePassword', [Map.class], { creds -> return creds })
+
+        helper.registerAllowedMethod('deleteDir', [], null)
+        helper.registerAllowedMethod('pwd', [], { 'workspaceDirMocked' })
+
+        helper.registerAllowedMethod('stash', [Map.class], null)
+        helper.registerAllowedMethod('unstash', [Map.class], null)
+
+        helper.registerAllowedMethod('checkout', [Closure.class], null)
+
+        helper.registerAllowedMethod('string', [Map.class], paramInterceptor)
+        helper.registerAllowedMethod('booleanParam', [Map.class], paramInterceptor)
+
+        helper.registerAllowedMethod('withEnv', [List.class, Closure.class], { List list, Closure c ->
+
+            list.each {
+                //def env = helper.get
+                def item = it.split('=')
+                assert item.size() == 2, "withEnv list does not look right: ${list.toString()}"
+                addEnvVar(item[0], item[1])
+                c.delegate = binding
+                c.call()
+            }
+        })
+
+        helper.registerAllowedMethod('credentials', [String], { String credName ->
+            return binding.getVariable('credentials')[credName]
+        })
+
+    }
+
+    /**
+     * Helper for adding a params value in tests
+     */
+    void addParam(String name, Object val, Boolean overWrite = false) {
+        Map params = binding.getVariable('params') as Map
+        if (params == null) {
+            params = [:]
+            binding.setVariable('params', params)
+        }
+        if (params[name] == null || overWrite) {
+            params[name] = val
+        }
+    }
+
+
+    /**
+     * Helper for adding a environment value in tests
+     */
+    void addEnvVar(String name, String val) {
+        Map env = binding.getVariable('env') as Map
+        if (env == null) {
+            env = [:]
+            binding.setVariable('env', env)
+        }
+        env[name] = val
+    }
+
+    void addCredential(String key, String val) {
+        Map credentials = binding.getVariable('credentials') as Map
+        if (credentials == null) {
+            credentials = [:]
+            binding.setVariable('credentials', credentials)
+        }
+        credentials[key] = val
+    }
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
@@ -1,6 +1,7 @@
 package com.lesfurets.jenkins.unit.declarative
 
 import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.createComponent
+import static groovy.lang.Closure.*
 
 abstract class GenericPipelineDeclaration {
 
@@ -10,13 +11,10 @@ abstract class GenericPipelineDeclaration {
     PostDeclaration post
 
     def agent(Object o) {
-        this.agent = new AgentDeclaration().with {
-            it.label = o
-            return it
-        }
+        this.agent = new AgentDeclaration().with { it.label = o; it }
     }
 
-    def agent(Closure closure) {
+    def agent(@DelegatesTo(strategy = DELEGATE_ONLY, value = AgentDeclaration) Closure closure) {
         this.agent = createComponent(AgentDeclaration, closure)
     }
 
@@ -28,7 +26,7 @@ abstract class GenericPipelineDeclaration {
         this.tools = closure
     }
 
-    def post(Closure closure) {
+    def post(@DelegatesTo(strategy = DELEGATE_ONLY, value = PostDeclaration) Closure closure) {
         this.post = createComponent(PostDeclaration, closure)
     }
 
@@ -37,7 +35,7 @@ abstract class GenericPipelineDeclaration {
         if (environment) {
             def env = delegate.binding.env
             def cl = this.environment.rehydrate(env, delegate, this)
-            cl.resolveStrategy = Closure.DELEGATE_FIRST
+            cl.resolveStrategy = DELEGATE_FIRST
             cl.call()
         }
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
@@ -32,7 +32,8 @@ abstract class GenericPipelineDeclaration {
 
     def execute(Object delegate) {
         // set environment
-        if (environment) {
+        println "this.environment = ${this.environment}"
+        if (this.environment) {
             def env = delegate.binding.env
             def cl = this.environment.rehydrate(env, delegate, this)
             cl.resolveStrategy = DELEGATE_FIRST

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
@@ -1,0 +1,45 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.createComponent
+
+abstract class GenericPipelineDeclaration {
+
+    AgentDeclaration agent
+    Closure environment
+    Closure tools
+    PostDeclaration post
+
+    def agent(Object o) {
+        this.agent = new AgentDeclaration().with {
+            it.label = o
+            return it
+        }
+    }
+
+    def agent(Closure closure) {
+        this.agent = createComponent(AgentDeclaration, closure)
+    }
+
+    def environment(Closure closure) {
+        this.environment = closure
+    }
+
+    def tools(Closure closure) {
+        this.tools = closure
+    }
+
+    def post(Closure closure) {
+        this.post = createComponent(PostDeclaration, closure)
+    }
+
+    def execute(Object delegate) {
+        // set environment
+        if (environment) {
+            def env = delegate.binding.env
+            def cl = this.environment.rehydrate(env, delegate, this)
+            cl.resolveStrategy = Closure.DELEGATE_FIRST
+            cl.call()
+        }
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
@@ -32,7 +32,6 @@ abstract class GenericPipelineDeclaration {
 
     def execute(Object delegate) {
         // set environment
-        println "this.environment = ${this.environment}"
         if (this.environment) {
             def env = delegate.binding.env
             def cl = this.environment.rehydrate(env, delegate, this)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ObjectUtils.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ObjectUtils.groovy
@@ -1,0 +1,15 @@
+package com.lesfurets.jenkins.unit.declarative
+
+class ObjectUtils {
+
+    static String printNonNullProperties(Object obj) {
+        def props = obj.properties
+        props.remove('class')
+        obj.properties.entrySet().forEach { e ->
+            if (e.value == null) {
+                props.remove(e.key)
+            }
+        }
+        return props.toString()
+    }
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
@@ -21,8 +21,11 @@ class ParallelDeclaration extends GenericPipelineDeclaration {
         this.stages.put(name, DeclarativePipeline.createComponent(StageDeclaration, closure).with{it.name = name;it} )
     }
 
-    Object execute(Object delegate) {
-
+    def execute(Object delegate) {
+        super.execute(delegate)
+        this.stages.entrySet().forEach { e ->
+            e.value.execute(delegate)
+        }
     }
 
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
@@ -1,0 +1,28 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static groovy.lang.Closure.DELEGATE_ONLY
+//import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeOn
+
+class ParallelDeclaration extends GenericPipelineDeclaration {
+
+    boolean failFast
+    Map<String, StageDeclaration> stages = [:]
+
+    ParallelDeclaration(boolean failFast) {
+        this.failFast = failFast
+    }
+
+    ParallelDeclaration() {
+        this.failFast = false
+    }
+
+    def stage(String name,
+              @DelegatesTo(strategy = DELEGATE_ONLY, value = StageDeclaration) Closure closure) {
+        this.stages.put(name, DeclarativePipeline.createComponent(StageDeclaration, closure).with{it.name = name;it} )
+    }
+
+    Object execute(Object delegate) {
+
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -33,21 +33,21 @@ class PostDeclaration {
     def execute(Object delegate) {
         def currentBuild = delegate.currentBuild.result
         if (this.always) {
-            executeOn(this.always, delegate)
+            executeOn(delegate, this.always)
         }
 
         switch (currentBuild) {
             case 'SUCCESS':
-                executeOn(this.success, delegate)
+                executeOn(delegate, this.success)
                 break
             case 'FAILURE':
-                executeOn(this.failure, delegate)
+                executeOn(delegate, this.failure)
                 break
             case 'UNSTABLE':
-                executeOn(this.unstable, delegate)
+                executeOn(delegate, this.unstable)
                 break
             case 'CHANGED':
-                executeOn(this.changed, delegate)
+                executeOn(delegate, this.changed)
                 break
         }
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -1,0 +1,55 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeOn
+
+class PostDeclaration {
+
+    Closure always
+    Closure changed
+    Closure success
+    Closure unstable
+    Closure failure
+
+    def always(Closure closure) {
+        this.always = closure
+    }
+
+    def changed(Closure closure) {
+        this.changed = closure
+    }
+
+    def success(Closure closure) {
+        this.success = closure
+    }
+
+    def unstable(Closure closure) {
+        this.unstable = closure
+    }
+
+    def failure(Closure closure) {
+        this.failure = closure
+    }
+
+    def execute(Object delegate) {
+        def currentBuild = delegate.currentBuild.result
+        if (this.always) {
+            executeOn(this.always, delegate)
+        }
+
+        switch (currentBuild) {
+            case 'SUCCESS':
+                executeOn(this.success, delegate)
+                break
+            case 'FAILURE':
+                executeOn(this.failure, delegate)
+                break
+            case 'UNSTABLE':
+                executeOn(this.unstable, delegate)
+                break
+            case 'CHANGED':
+                executeOn(this.changed, delegate)
+                break
+        }
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
@@ -33,12 +33,17 @@ class StageDeclaration extends GenericPipelineDeclaration {
 
     def execute(Object delegate) {
         String name = this.name
+        if(parallel) {
+            parallel.execute(delegate)
+        }
         if (!when || when.execute(delegate)) {
             super.execute(delegate)
             // TODO handle credentials
-            Closure stageBody = { agent?.execute(delegate) } >> steps.rehydrate(delegate, delegate, delegate)
-            Closure cl = { stage("$name", stageBody) }
-            executeWith(delegate, cl)
+            if(steps) {
+                Closure stageBody = { agent?.execute(delegate) } >> steps.rehydrate(delegate, delegate, delegate)
+                Closure cl = { stage("$name", stageBody) }
+                executeWith(delegate, cl)
+            }
             if (post) {
                 this.post.execute(delegate)
             }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
@@ -8,6 +8,8 @@ class StageDeclaration extends GenericPipelineDeclaration {
     String name
     Closure steps
     WhenDeclaration when
+    ParallelDeclaration parallel
+    boolean failFast = false
 
     StageDeclaration(String name) {
         this.name = name
@@ -15,6 +17,14 @@ class StageDeclaration extends GenericPipelineDeclaration {
 
     def steps(Closure closure) {
         this.steps = closure
+    }
+
+    def failFast(boolean failFast) {
+        this.failFast = failFast
+    }
+
+    def parallel(@DelegatesTo(strategy = DELEGATE_ONLY, value = ParallelDeclaration) Closure closure) {
+        this.parallel = DeclarativePipeline.createComponent(ParallelDeclaration, closure).with { it.failFast = failFast; it }
     }
 
     def when(@DelegatesTo(strategy = DELEGATE_ONLY, value = WhenDeclaration) Closure closure) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
@@ -1,0 +1,39 @@
+package com.lesfurets.jenkins.unit.declarative
+
+class StageDeclaration extends GenericPipelineDeclaration {
+
+    String name
+    Closure steps
+    WhenDeclaration when
+
+    StageDeclaration(String name) {
+        this.name = name
+    }
+
+    def steps(Closure closure) {
+        this.steps = closure
+    }
+
+    def when(Closure closure) {
+        this.when = DeclarativePipeline.createComponent(WhenDeclaration, closure)
+    }
+
+    def execute(Object delegate) {
+        if (!when || when.execute(delegate)) {
+            super.execute(delegate)
+            // TODO handle credentials
+            Closure inside = { agent?.execute(delegate) } >> steps.rehydrate(delegate, this, this)
+            Closure cl = { stage("$name", inside) }
+            def stepsCl = cl.rehydrate(delegate, this, this)
+            stepsCl.resolveStrategy = Closure.DELEGATE_FIRST
+            stepsCl.call()
+            if (post) {
+                this.post.execute(delegate)
+            }
+        } else {
+            Closure cl = { echo "Skipping stage $name" }
+            cl.rehydrate(delegate, this, this).call()
+        }
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -1,5 +1,7 @@
 package com.lesfurets.jenkins.unit.declarative
 
+import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeWith
+
 class WhenDeclaration {
 
     String branch
@@ -27,7 +29,7 @@ class WhenDeclaration {
         boolean br = true
         boolean env = true
         if (expression) {
-            exp = expression.rehydrate(delegate, this, this).call()
+            exp = executeWith(delegate, expression)
         }
         if (branch) {
             br = this.branch == delegate.env.BRANCH_NAME

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -1,0 +1,43 @@
+package com.lesfurets.jenkins.unit.declarative
+
+class WhenDeclaration {
+
+    String branch
+    Closure<Boolean> expression
+    Map<String, Object> environment = [:]
+
+    def environment(String name, Object value) {
+        this.environment.put(name, value)
+    }
+
+    def environment(envs) {
+        this.environment(envs.name, envs.value)
+    }
+
+    def branch (String name) {
+        this.branch = name
+    }
+
+    def expression(Closure closure) {
+        this.expression = closure
+    }
+
+    boolean execute(Object delegate) {
+        boolean exp = true
+        boolean br = true
+        boolean env = true
+        if (expression) {
+            exp = expression.rehydrate(delegate, this, this).call()
+        }
+        if (branch) {
+            br = this.branch == delegate.env.BRANCH_NAME
+        }
+        if (!environment.isEmpty()) {
+            environment.entrySet().forEach { e ->
+                env = env && (delegate.env."${e.key}" == e.value)
+            }
+        }
+        return exp && br && env
+    }
+
+}

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -1,0 +1,76 @@
+package com.lesfurets.jenkins.unit.declarative
+
+import static org.assertj.core.api.Assertions.*
+
+import org.junit.Before
+import org.junit.Test
+
+class TestDeclarativePipeline extends DeclarativePipelineTest {
+
+    @Before
+    @Override
+    void setUp() throws Exception {
+        scriptRoots = ['src/test/jenkins/jenkinsfiles']
+        scriptExtension = ''
+        super.setUp()
+    }
+
+    @Test void jenkinsfile_success() throws Exception {
+        def script = loadScript('Declarative_Jenkinsfile')
+        printCallStack()
+        assertJobStatusSuccess()
+        assertThat(script.currentBuild.result).isEqualTo('SUCCESS')
+        assertCallStackContains('pipeline unit tests PASSED')
+        assertCallStackContains('pipeline unit tests completed')
+    }
+
+    @Test void jenkinsfile_failure() throws Exception {
+        helper.registerAllowedMethod('sh', [String.class], { String cmd ->
+            updateBuildStatus('FAILURE')
+        })
+        loadScript('Declarative_Jenkinsfile')
+        printCallStack()
+        assertJobStatusFailure()
+        assertCallStack()
+        assertCallStack().contains('pipeline unit tests FAILED')
+        assertCallStackContains('pipeline unit tests completed')
+    }
+
+    @Test void should_params() throws Exception {
+        loadScript('Params_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Hello Mr Jenkins')
+    }
+
+    @Test void when_branch() throws Exception {
+        addEnvVar('BRANCH_NAME', 'production')
+        loadScript('Branch_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Deploying')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_branch_not() throws Exception {
+        addEnvVar('BRANCH_NAME', 'master')
+        loadScript('Branch_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Skipping')
+        assertJobStatusSuccess()
+    }
+
+    @Test void should_agent() throws Exception {
+        loadScript('Agent_Jenkinsfile')
+        printCallStack()
+        assertJobStatusSuccess()
+        assertCallStack().contains('openjdk:8-jre')
+        assertCallStack().contains('maven:3-alpine')
+    }
+
+    @Test void should_credentials() throws Exception {
+        addCredential('my-prefined-secret-text', 'something_secret')
+        loadScript('Credentials_Jenkinsfile')
+        printCallStack()
+        assertJobStatusSuccess()
+        assertCallStack().contains('AN_ACCESS_KEY:something_secret')
+    }
+}

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -16,10 +16,9 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
     }
 
     @Test void jenkinsfile_success() throws Exception {
-        def script = loadScript('Declarative_Jenkinsfile')
+        def script = runScript('Declarative_Jenkinsfile')
         printCallStack()
         assertJobStatusSuccess()
-        assertThat(script.currentBuild.result).isEqualTo('SUCCESS')
         assertCallStackContains('pipeline unit tests PASSED')
         assertCallStackContains('pipeline unit tests completed')
     }
@@ -28,7 +27,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
             updateBuildStatus('FAILURE')
         })
-        loadScript('Declarative_Jenkinsfile')
+        runScript('Declarative_Jenkinsfile')
         printCallStack()
         assertJobStatusFailure()
         assertCallStack()
@@ -37,14 +36,14 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
     }
 
     @Test void should_params() throws Exception {
-        loadScript('Params_Jenkinsfile')
+        runScript('Params_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('Hello Mr Jenkins')
     }
 
     @Test void when_branch() throws Exception {
         addEnvVar('BRANCH_NAME', 'production')
-        loadScript('Branch_Jenkinsfile')
+        runScript('Branch_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('Deploying')
         assertJobStatusSuccess()
@@ -52,14 +51,14 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
 
     @Test void when_branch_not() throws Exception {
         addEnvVar('BRANCH_NAME', 'master')
-        loadScript('Branch_Jenkinsfile')
+        runScript('Branch_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('Skipping stage Example Deploy')
         assertJobStatusSuccess()
     }
 
     @Test void should_agent() throws Exception {
-        loadScript('Agent_Jenkinsfile')
+        runScript('Agent_Jenkinsfile')
         printCallStack()
         assertJobStatusSuccess()
         assertCallStack().contains('openjdk:8-jre')
@@ -68,16 +67,22 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
 
     @Test void should_credentials() throws Exception {
         addCredential('my-prefined-secret-text', 'something_secret')
-        loadScript('Credentials_Jenkinsfile')
+        runScript('Credentials_Jenkinsfile')
         printCallStack()
         assertJobStatusSuccess()
         assertCallStack().contains('AN_ACCESS_KEY:something_secret')
     }
 
+    @Test void should_parallel() throws Exception {
+        runScript('Parallel_Jenkinsfile')
+        printCallStack()
+        assertJobStatusSuccess()
+    }
+
     @Test(expected = MissingPropertyException)
     void should_non_valid_fail() throws Exception {
         try {
-            loadScript('Non_Valid_Jenkinsfile')
+            runScript('Non_Valid_Jenkinsfile')
         } catch (e) {
             e.printStackTrace()
             throw e

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -54,7 +54,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         addEnvVar('BRANCH_NAME', 'master')
         loadScript('Branch_Jenkinsfile')
         printCallStack()
-        assertCallStack().contains('Skipping')
+        assertCallStack().contains('Skipping stage Example Deploy')
         assertJobStatusSuccess()
     }
 
@@ -72,5 +72,17 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         printCallStack()
         assertJobStatusSuccess()
         assertCallStack().contains('AN_ACCESS_KEY:something_secret')
+    }
+
+    @Test(expected = MissingPropertyException)
+    void should_non_valid_fail() throws Exception {
+        try {
+            loadScript('Non_Valid_Jenkinsfile')
+        } catch (e) {
+            e.printStackTrace()
+            throw e
+        } finally {
+            printCallStack()
+        }
     }
 }

--- a/src/test/jenkins/jenkinsfiles/Agent_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Agent_Jenkinsfile
@@ -1,0 +1,19 @@
+pipeline {
+    agent none
+    stages {
+        stage('Example Build') {
+            agent { docker 'maven:3-alpine' }
+            steps {
+                echo 'Hello, Maven'
+                sh 'mvn --version'
+            }
+        }
+        stage('Example Test') {
+            agent { docker 'openjdk:8-jre' }
+            steps {
+                echo 'Hello, JDK'
+                sh 'java -version'
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Branch_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Branch_Jenkinsfile
@@ -1,0 +1,18 @@
+pipeline {
+    agent any
+    stages {
+        stage('Example Build') {
+            steps {
+                echo 'Hello World'
+            }
+        }
+        stage('Example Deploy') {
+            when {
+                branch 'production'
+            }
+            steps {
+                echo 'Deploying'
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Credentials_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Credentials_Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+    environment {
+        CC = 'clang'
+    }
+    stages {
+        stage('Example') {
+            environment {
+                AN_ACCESS_KEY = credentials('my-prefined-secret-text')
+            }
+            steps {
+                sh 'printenv'
+                echo "${env}"
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
@@ -1,0 +1,75 @@
+pipeline {
+
+    agent any
+
+    environment {
+        CC = 'gcc'
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timestamps()
+    }
+
+    triggers {
+        pollSCM('*/5 * * * *')
+    }
+
+    stages {
+
+        stage('Checkout') {
+            when {
+                environment name: 'CC', value: 'clang'
+            }
+            steps {
+                deleteDir()
+                checkout scm
+            }
+        }
+
+        stage('build') {
+            agent { docker 'maven:3-alpine' }
+            steps {
+                withEnv(["GRADLE_HOME=${tool name: 'GRADLE_3', type: 'hudson.plugins.gradle.GradleInstallation'}"]) {
+                    withEnv(["PATH=${env.PATH}:${env.GRADLE_HOME}/bin"]) {
+
+                        // Checking the env
+                        echo "GRADLE_HOME=${env.GRADLE_HOME}"
+                        echo "PATH=${env.PATH}"
+
+                        sh 'gradle clean build test -i'
+                    }
+                }
+            }
+        }
+
+        stage('validate') {
+            steps {
+                echo 'DONE: syntactic validation of Jenkinsfiles'
+            }
+        }
+    }
+
+    post {
+        always {
+            echo 'pipeline unit tests completed'
+        }
+
+        success {
+            echo 'pipeline unit tests PASSED'
+        }
+
+        failure {
+            echo 'pipeline unit tests FAILED'
+        }
+
+        changed {
+            echo 'pipeline unit tests results have CHANGED'
+        }
+
+        unstable {
+            echo 'pipeline unit tests have gone UNSTABLE'
+        }
+
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Non_Valid_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Non_Valid_Jenkinsfile
@@ -1,0 +1,20 @@
+pipeline {
+    agent none
+    stages {
+        stage('Example Build') {
+            agent { docker 'maven:3-alpine' }
+            steps {
+                echo 'Hello, Maven'
+                sh 'mvn --version'
+            }
+        }
+        stage('Example Test') {
+            agent { docker 'openjdk:8-jre' }
+            steps {
+                echo "$name"
+                echo 'Hello, JDK'
+                sh 'java -version'
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Parallel_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Parallel_Jenkinsfile
@@ -1,0 +1,36 @@
+pipeline {
+    agent none
+    stages {
+        stage('Run Tests') {
+            failFast true
+            parallel {
+                stage('Test On Windows') {
+                    agent {
+                        label "windows"
+                    }
+                    steps {
+                        bat "run-tests.bat"
+                    }
+                    post {
+                        always {
+                            junit "**/TEST-*.xml"
+                        }
+                    }
+                }
+                stage('Test On Linux') {
+                    agent {
+                        label "linux"
+                    }
+                    steps {
+                        sh "run-tests.sh"
+                    }
+                    post {
+                        always {
+                            junit "**/TEST-*.xml"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Parallel_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Parallel_Jenkinsfile
@@ -9,12 +9,7 @@ pipeline {
                         label "windows"
                     }
                     steps {
-                        bat "run-tests.bat"
-                    }
-                    post {
-                        always {
-                            junit "**/TEST-*.xml"
-                        }
+                        sh "run-tests.exe"
                     }
                 }
                 stage('Test On Linux') {
@@ -23,11 +18,6 @@ pipeline {
                     }
                     steps {
                         sh "run-tests.sh"
-                    }
-                    post {
-                        always {
-                            junit "**/TEST-*.xml"
-                        }
                     }
                 }
             }

--- a/src/test/jenkins/jenkinsfiles/Params_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Params_Jenkinsfile
@@ -1,0 +1,13 @@
+pipeline {
+    agent any
+    parameters {
+        string(name: 'PERSON', defaultValue: 'Mr Jenkins', description: 'Who should I say hello to?')
+    }
+    stages {
+        stage('Example') {
+            steps {
+                echo "Hello ${params.PERSON}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support for testing declarative pipeline syntax.

Provides a DeclarativePipelineTest base class that 
- Does syntactic checking of the declarative pipeline model
- Mocks the [ModelInterpreter](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy) provided by the [pipeline-model-definition-plugin](https://github.com/jenkinsci/pipeline-model-definition-plugin) and sets props/params/credentials etc. and calls steps on stages, with when predicates and post actions.

Yet there are several caveats with this approach: 
- It does not verify whether there is any if,else,loop instructions on regular steps blocks, 
- Mock model interpreters should be easily extensible by users, which is not possible for now. For now the only extension point is the `pipeline` keyword, which involves rewriting every model interpreter.
 DeclarativePipelineTest does not use CPS transformation so it does not verify the pipeline against serialization issues.

