### PR TITLE
testNonRegression: Generate actual files on error

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -32,6 +32,11 @@ class RegressionTestHelper {
         String callStack = helper.callStack.join('\n') + '\n'
         final expected = referenceFile.text.normalize()
         final actual = callStack.normalize()
+        if (!expected.equals(actual)) {
+            final actualFileName = targetFileName + ".actual"
+            final actualFile = new File(actualFileName)
+            writeStackToFile(actualFile, helper)
+        }
         assertThat(actual)
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
                         .isEqualTo(expected)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -31,7 +31,8 @@ class RegressionTestHelper {
 
         String callStack = helper.callStack.join('\n') + '\n'
         final expected = referenceFile.text.normalize()
-        assertThat(callStack.normalize())
+        final actual = callStack.normalize()
+        assertThat(actual)
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
                         .isEqualTo(expected)
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -30,9 +30,10 @@ class RegressionTestHelper {
         }
 
         String callStack = helper.callStack.join('\n') + '\n'
+        final expected = referenceFile.text.normalize()
         assertThat(callStack.normalize())
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
-                        .isEqualTo(referenceFile.text.normalize())
+                        .isEqualTo(expected)
     }
 
     private static writeStackToFile(File referenceFile, PipelineTestHelper helper) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -25,7 +25,7 @@ class RegressionTestHelper {
         targetFileName += '.txt'
         def referenceFile = new File(targetFileName)
         def pipelineStackWrite = System.getProperty(PIPELINE_STACK_WRITE)
-        if (pipelineStackWrite && Boolean.valueOf(pipelineStackWrite)) {
+        if (!referenceFile.isFile() || (pipelineStackWrite && Boolean.valueOf(pipelineStackWrite))) {
             writeStackToFile(referenceFile, helper)
         }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -32,9 +32,9 @@ class RegressionTestHelper {
         String callStack = helper.callStack.join('\n') + '\n'
         final expected = referenceFile.text.normalize()
         final actual = callStack.normalize()
+        final actualFileName = targetFileName + ".actual"
+        final actualFile = new File(actualFileName)
         if (!expected.equals(actual)) {
-            final actualFileName = targetFileName + ".actual"
-            final actualFile = new File(actualFileName)
             writeStackToFile(actualFile, helper)
         }
         assertThat(actual)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -34,6 +34,9 @@ class RegressionTestHelper {
         final actual = callStack.normalize()
         final actualFileName = targetFileName + ".actual"
         final actualFile = new File(actualFileName)
+        if (actualFile.isFile()) {
+            actualFile.delete()
+        }
         if (!expected.equals(actual)) {
             writeStackToFile(actualFile, helper)
         }

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
@@ -1,5 +1,6 @@
 package com.lesfurets.jenkins
 
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
@@ -32,6 +33,21 @@ class TestRegression extends BaseRegressionTestCPS {
         def script = runScript("job/exampleJob.jenkins")
         script.execute()
         super.testNonRegression("example")
+    }
+
+    @Test
+    void testNonRegression_ExpectedFileIsCreatedIfItDidNotExist() throws Exception {
+        final expectedFile = new File("src/test/resources/callstacks/TestRegression_missing.txt")
+        if (expectedFile.isFile()) {
+            expectedFile.delete()
+        }
+        def script = runScript("job/exampleJob.jenkins")
+        script.execute()
+
+        super.testNonRegression("missing")
+
+        Assert.assertTrue("The file '${expectedFile}' should have been created", expectedFile.isFile())
+        expectedFile.delete()
     }
 
 }

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
@@ -73,4 +73,16 @@ class TestRegression extends BaseRegressionTestCPS {
         expectedFile.delete()
     }
 
+    @Test
+    void testNonRegression_deletesActualFileFirst() throws Exception {
+        final expectedFile = new File("src/test/resources/callstacks/TestRegression_example.txt.actual")
+        expectedFile.text = "temporary text"
+        def script = runScript("job/exampleJob.jenkins")
+        script.execute()
+
+        super.testNonRegression("example")
+
+        Assert.assertFalse("The file '${expectedFile}' should have been deleted", expectedFile.isFile())
+    }
+
 }

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
@@ -50,4 +50,27 @@ class TestRegression extends BaseRegressionTestCPS {
         expectedFile.delete()
     }
 
+    @Test
+    void testNonRegression_writesActualFileOnFailure() throws Exception {
+        final expectedFile = new File("src/test/resources/callstacks/TestRegression_example.txt.actual")
+        if (expectedFile.isFile()) {
+            expectedFile.delete()
+        }
+        def script = runScript("job/exampleJob.jenkins")
+        helper.registerAllowedMethod("sh", [Map.class], {c -> 'bcc19742'})
+        script.execute()
+
+        boolean thrown = false
+        try {
+            super.testNonRegression("example")
+        }
+        catch (final AssertionError ignored) {
+            thrown = true;
+        }
+
+        Assert.assertTrue("testNonRegression should have thrown an AssertionError", thrown)
+        Assert.assertTrue("The file '${expectedFile}' should have been created", expectedFile.isFile())
+        expectedFile.delete()
+    }
+
 }


### PR DESCRIPTION
`testNonRegression` is insanely useful to write characterization tests and then maintain those tests as changes are made subsequently to the `Jenkinsfile`.

The point of this pull request is to add a feature that replaces the need to add this code to my test suites:
```
// uncomment the line below when you want to update the reference callstacks
//System.setProperty(RegressionTestHelper.PIPELINE_STACK_WRITE, "true");
```
...such that if the output of a run changes, I don't have to:
1. Temporarily un-comment the line
2. Re-run the test
3. Re-comment the line

I instead can fire up my diff tool and _copy_ the changes from the newly-generated `.actual` file into the corresponding suite file (if I want to).

As a bonus, the "expected" file will now be written if one didn't exist before, instead of the corresponding test failing with a `FileNotFoundException`.

Please let me know if there are additional tests you would like me to write/run.

Thanks!