### PR TITLE
Use same method interceptors for library scripts

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -382,6 +382,9 @@ class PipelineTestHelper {
                     this.registerAllowedMethod(method(e.value.class.name, m.getNativeParameterTypes()),
                                     { args -> m.doMethodInvoke(e.value, args) })
                 }
+                script.metaClass.invokeMethod = getMethodInterceptor()
+                script.metaClass.static.invokeMethod = getMethodInterceptor()
+                script.metaClass.methodMissing = getMethodMissingInterceptor()
             }
             binding.setVariable(e.key, e.value)
         }


### PR DESCRIPTION
Provide fix for #71 . 

Force library scripts to use same method interceptor as the scripts loaded through `PipelineTestHelper.loadScript`.