### PR TITLE
Add HelperSingleton to cache PipelineTestHelper

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -32,19 +32,29 @@ abstract class BasePipelineTest {
     }
 
     BasePipelineTest() {
-        helper = new PipelineTestHelper()
+        helper = HelperSingleton.getSingletonInstance()
     }
 
     void setUp() throws Exception {
-        helper.with {
-            it.scriptRoots = this.scriptRoots
-            it.scriptExtension = this.scriptExtension
-            it.baseClassloader = this.baseClassLoader
-            it.imports += this.imports
-            it.baseScriptRoot = this.baseScriptRoot
-            return it
-        }.init()
 
+        if (!helper.isInitialized()) {
+            helper.with {
+                it.scriptRoots = this.scriptRoots
+                it.scriptExtension = this.scriptExtension
+                it.baseClassloader = this.baseClassLoader
+                it.imports += this.imports
+                it.baseScriptRoot = this.baseScriptRoot
+            }
+
+            helper.init()
+
+            registerDefaultAllowedMethods()
+        }
+
+        binding.setVariable('currentBuild', [result: 'SUCCESS'])
+    }
+
+    void registerDefaultAllowedMethods() {
         helper.registerAllowedMethod("stage", [String.class, Closure.class], null)
         helper.registerAllowedMethod("stage", [String.class, Closure.class], null)
         helper.registerAllowedMethod("node", [String.class, Closure.class], null)
@@ -74,8 +84,6 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("string", [Map.class], stringInterceptor)
         helper.registerAllowedMethod("withCredentials", [List.class, Closure.class], withCredentialsInterceptor)
         helper.registerAllowedMethod("error", [String.class], { updateBuildStatus('FAILURE') })
-
-        binding.setVariable('currentBuild', [result: 'SUCCESS'])
     }
 
     /**

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -49,6 +49,8 @@ abstract class BasePipelineTest {
             helper.init()
 
             registerDefaultAllowedMethods()
+        } else {
+            helper.callStack.clear()
         }
 
         binding.setVariable('currentBuild', [result: 'SUCCESS'])

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -32,7 +32,7 @@ abstract class BasePipelineTest {
     }
 
     BasePipelineTest() {
-        helper = HelperSingleton.getSingletonInstance()
+        helper = HelperSingleton.singletonInstance
     }
 
     void setUp() throws Exception {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/HelperSingleton.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/HelperSingleton.groovy
@@ -1,0 +1,23 @@
+package com.lesfurets.jenkins.unit
+
+class HelperSingleton {
+
+    static PipelineTestHelper singletonInstance;
+
+    static void setSingletonInstance(PipelineTestHelper helper) {
+        singletonInstance = helper
+    }
+
+    static PipelineTestHelper getSingletonInstance() {
+
+        if (singletonInstance != null) {
+            return singletonInstance
+        }
+
+        return new PipelineTestHelper()
+    }
+
+    static void invalidate() {
+        setSingletonInstance(null)
+    }
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -259,7 +259,7 @@ class PipelineTestHelper {
      *
      * @return true if internal GroovyScriptEngine is set
      */
-    protected boolean isInitialized() {
+    boolean isInitialized() {
         return gse != null
     }
 

--- a/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
@@ -1,0 +1,59 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import com.lesfurets.jenkins.unit.HelperSingleton
+import com.lesfurets.jenkins.unit.PipelineTestHelper
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.LocalSource.localSource
+import static org.assertj.core.api.Assertions.assertThat
+
+class TestHelperSingleton extends BasePipelineTest {
+
+    @BeforeClass
+    static void beforeClass() {
+        HelperSingleton.singletonInstance = new PipelineTestHelper()
+
+        String sharedLibs = this.class.getResource('/libs').getFile()
+
+        def library = library().name('commons')
+                .defaultVersion("master")
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath(sharedLibs)
+                .retriever(localSource(sharedLibs))
+                .build()
+
+        HelperSingleton.singletonInstance.registerSharedLibrary(library)
+    }
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+    }
+
+    @Test
+    void staticHelperTestRunScript() throws Exception {
+
+        assertThat(helper.isInitialized())
+
+        assertThat(helper == HelperSingleton.singletonInstance)
+
+        boolean exception = false
+        try {
+            def script = runScript("job/library/libraryJob.jenkins")
+            script.execute()
+            printCallStack()
+        } catch (e) {
+            e.printStackTrace()
+            exception = true
+        }
+        assertThat(false).isEqualTo(exception)
+    }
+
+}

--- a/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
@@ -3,6 +3,7 @@ package com.lesfurets.jenkins
 import com.lesfurets.jenkins.unit.BasePipelineTest
 import com.lesfurets.jenkins.unit.HelperSingleton
 import com.lesfurets.jenkins.unit.PipelineTestHelper
+import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -54,6 +55,11 @@ class TestHelperSingleton extends BasePipelineTest {
             exception = true
         }
         assertThat(false).isEqualTo(exception)
+    }
+
+    @AfterClass
+    static void tearDown() {
+        HelperSingleton.invalidate()
     }
 
 }


### PR DESCRIPTION
Feature implementation for #73 

Adds a singleton for the `PipelineTestHelper` class. This can especially be used in a `@BeforeClass` static junit method so the singleton instance and dependent libraries will be used during the whole test execution.