### PR TITLE
Update library loading so branch not required for localSource locations.

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LibraryConfiguration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LibraryConfiguration.groovy
@@ -18,7 +18,7 @@ class LibraryConfiguration {
     String targetPath
 
     LibraryConfiguration validate() {
-        if (name && defaultVersion && retriever && targetPath)
+        if (name && retriever && targetPath && ((retriever instanceof LocalSource) || defaultVersion))
             return this
         throw new IllegalStateException("LibraryConfiguration is not properly initialized ${this.toString()}")
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LocalSource.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LocalSource.groovy
@@ -11,7 +11,14 @@ class LocalSource implements SourceRetriever {
 
     @Override
     List<URL> retrieve(String repository, String branch, String targetPath) {
-        def sourceDir = new File(sourceURL).toPath().resolve("$repository@$branch").toFile()
+        def sourceURLPath = new File(sourceURL).toPath()
+        def sourceDir
+        if (branch) {
+            sourceDir = sourceURLPath.resolve("$repository@$branch").toFile()
+        } else {
+            sourceDir = sourceURLPath.resolve(repository).toFile()
+        }
+
         if (sourceDir.exists()) {
             return [sourceDir.toURI().toURL()]
         }


### PR DESCRIPTION
I was trying to use JenkinsPipelineUnit to test a library I'm writing. I want to use this from within local 
copy (clone) of the repo using the localSource retriever. This was problematic as the code required
setting defaultVersion (branch) which it then appended to the path to the library root.

This PR allows the following usage:

```
        def library = library()
                .name('jenkins-library')
                .allowOverride(true)
                .implicit(false)
                .targetPath(dirPath)
                .retriever(localSource(dirPath))
                .build()
        helper.registerSharedLibrary(library)
```
where `dirPath` is the project root, without `@<branch>` or other version identifier required in the filesystem path.

I'm not a Java or Groovy coder so this PR probably has issues so any feedback welcome (even if it's just pointing out that I'm not using it properly! :) )
