### PR TITLE
issue-80: Fix invalid code snippet in the configuration section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ class TestExampleJob extends BasePipelineTest {
     @Override
     @Before
     void setUp() throws Exception {
-        helper.baseScriptRoot = 'jenkinsJobs'
-        helper.roots += 'src/main/groovy'
-        helper.extension = 'pipeline'
+        baseScriptRoot = 'jenkinsJobs'
+        scriptRoots += 'src/main/groovy'
+        scriptExtension = 'pipeline'
         super.setUp()
     }
     


### PR DESCRIPTION
This change is to fix documentation to use BasePipelineTest's properties instead of helper's ones.


https://github.com/angry-cellophane/JenkinsPipelineUnit#configuration
Overriding these default values is easy:
```
class TestExampleJob extends BasePipelineTest {

    @Override
    @Before
    void setUp() throws Exception {
        helper.baseScriptRoot = 'jenkinsJobs'
        helper.roots += 'src/main/groovy'
        helper.extension = 'pipeline'
        super.setUp()
    }   
}
```
if I use this code snippet to customize my pipeline test I have an exception that my file is not found.
I use a typical maven project structure

```
└── src
    ├── main
    │   └── groovy
    │      
    └── test
        ├── groovy
        └── resources
```
This happens because helper's properties are overridden by BasePipelineTest's properties.
https://github.com/angry-cellophane/JenkinsPipelineUnit/blob/master/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
```
    void setUp() throws Exception {
        helper.with {
            it.scriptRoots = this.scriptRoots
            it.scriptExtension = this.scriptExtension
            it.baseClassloader = this.baseClassLoader
            it.imports += this.imports
            it.baseScriptRoot = this.baseScriptRoot
            return it
        }.init()
        //...
   }
```
If I use BasePipelineTest's properties the test works fine
```
class TestExampleJob extends BasePipelineTest {

    @Override
    @Before
    void setUp() throws Exception {
        baseScriptRoot = 'jenkinsJobs'
        roots += 'src/main/groovy'
        extension = 'pipeline'
        super.setUp()
    }   
}
```