### PR TITLE
Fixed intercepting GCL for Global Shared Libraries

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -16,7 +16,7 @@ class InterceptingGCL extends GroovyClassLoader {
 
     @Override
     Class parseClass(GroovyCodeSource codeSource, boolean shouldCacheSource)
-                    throws CompilationFailedException {
+            throws CompilationFailedException {
         Class clazz = super.parseClass(codeSource, shouldCacheSource)
         clazz.metaClass.invokeMethod = helper.getMethodInterceptor()
         clazz.metaClass.static.invokeMethod = helper.getMethodInterceptor()
@@ -26,10 +26,32 @@ class InterceptingGCL extends GroovyClassLoader {
 
     @Override
     Class<?> loadClass(String name) throws ClassNotFoundException {
-        Class<?> clazz = super.loadClass(name)
-        clazz.metaClass.invokeMethod = helper.getMethodInterceptor()
-        clazz.metaClass.static.invokeMethod = helper.getMethodInterceptor()
-        clazz.metaClass.methodMissing = helper.getMethodMissingInterceptor()
-        return clazz
+        // Source from: groovy-all-2.4.6-sources.jar!/groovy/lang/GroovyClassLoader.java:710
+        Class cls = null
+        // try groovy file
+        try {
+            URL source = resourceLoader.loadGroovySource(name);
+            // if recompilation fails, we want cls==null
+            cls = recompile(source, name, null);
+        } catch (IOException ioe) {
+        } finally {
+            if (cls == null) {
+                removeClassCacheEntry(name);
+            } else {
+                setClassCacheEntry(cls);
+            }
+        }
+
+        if (cls == null) {
+            // no class found, there should have been an exception before now
+            throw new AssertionError(true);
+        }
+
+        // Copy from this.parseClass(GroovyCodeSource, boolean)
+        cls.metaClass.invokeMethod = helper.getMethodInterceptor()
+        cls.metaClass.static.invokeMethod = helper.getMethodInterceptor()
+        cls.metaClass.methodMissing = helper.getMethodMissingInterceptor()
+
+        return cls;
     }
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -43,8 +43,8 @@ class InterceptingGCL extends GroovyClassLoader {
         }
 
         if (cls == null) {
-            // no class found, there should have been an exception before now
-            throw new AssertionError(true);
+            // no class found, using parent's method
+            return super.loadClass(name)
         }
 
         // Copy from this.parseClass(GroovyCodeSource, boolean)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -23,4 +23,13 @@ class InterceptingGCL extends GroovyClassLoader {
         clazz.metaClass.methodMissing = helper.getMethodMissingInterceptor()
         return clazz
     }
+
+    @Override
+    Class<?> loadClass(String name) throws ClassNotFoundException {
+        Class<?> clazz = super.loadClass(name)
+        clazz.metaClass.invokeMethod = helper.getMethodInterceptor()
+        clazz.metaClass.static.invokeMethod = helper.getMethodInterceptor()
+        clazz.metaClass.methodMissing = helper.getMethodMissingInterceptor()
+        return clazz
+    }
 }


### PR DESCRIPTION
There is an issue with Intercepting GCL. The parseClass method is never executed thus making libraries attached by e.g.: `helper.registerSharedLibrary(library)` not able to execute Jenkins native methods (ones registered by `registerAllowedMethod` etc). 

This PR fixes the issue and allows to test the global shared libraries locally.

I guess it also fixes issue #51.

P.S. I haven't removed the old parseClass as I'm not sure if it is not executing all the time or only for this particular case.