### PR TITLE
registerMethodCall in PipelineTestHelper should clone the method args

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -264,6 +264,30 @@ class PipelineTestHelper {
     }
 
     /**
+     * Clone argments for registerMethodCall so they are recorded
+     * at the time the method is called in case of changes to an
+     * arg variable later in the pipeline.
+     *
+     * @param args original args passed to the method call
+     * @return cloned args
+     */
+    private Object[] cloneArgs(Object[] args) {
+
+        List argsCloned = []
+        args.each {
+            try {
+                // Try the clone
+                argsCloned << it?.clone()
+            }
+            catch(e) {
+                // Cannot clone it, get a string representation at this point.
+                argsCloned << it.toString()
+            }
+        }
+        return argsCloned as Object[]
+    }
+
+    /**
      * Register method call to call stack
      * @param target target object
      * @param stackDepth depth in stack
@@ -274,7 +298,7 @@ class PipelineTestHelper {
         MethodCall call = new MethodCall()
         call.target = target
         call.methodName = name
-        call.args = args
+        call.args = cloneArgs(args)
         call.stackDepth = stackDepth
         callStack.add(call)
     }

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegressionGlobalVar.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegressionGlobalVar.groovy
@@ -1,0 +1,23 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.cps.BaseRegressionTestCPS
+import org.junit.Before
+import org.junit.Test
+
+class TestRegressionGlobalVar extends BaseRegressionTestCPS {
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+        helper.registerAllowedMethod("doWithProperties", [Properties.class], null)
+    }
+
+    @Test
+    void testGlobalVarRegression() throws Exception {
+        runScript("job/globalVar.jenkins")
+        super.testNonRegression("globalVar")
+    }
+
+}

--- a/src/test/jenkins/job/globalVar.jenkins
+++ b/src/test/jenkins/job/globalVar.jenkins
@@ -1,0 +1,25 @@
+#!groovy
+
+Properties p = new Properties()
+
+node() {
+
+    stage('One') {
+
+        echo "Stage One"
+
+        p.setProperty('PROP_1', 'VAL_1')
+
+        doWithProperties(p)
+    }
+
+    stage('Two') {
+
+        echo "Stage Two"
+
+        p.setProperty('PROP_2', 'VAL_2')
+
+        doWithProperties(p)
+    }
+}
+

--- a/src/test/resources/callstacks/TestRegressionGlobalVar_globalVar.txt
+++ b/src/test/resources/callstacks/TestRegressionGlobalVar_globalVar.txt
@@ -1,0 +1,8 @@
+   globalVar.run()
+      globalVar.node(groovy.lang.Closure)
+         globalVar.stage(One, groovy.lang.Closure)
+            globalVar.echo(Stage One)
+            globalVar.doWithProperties({PROP_1=VAL_1})
+         globalVar.stage(Two, groovy.lang.Closure)
+            globalVar.echo(Stage Two)
+            globalVar.doWithProperties({PROP_2=VAL_2, PROP_1=VAL_1})


### PR DESCRIPTION
registerMethodCall in PipelineTestHelper should clone the method arg as they may change later in the pipeline execution. This fixes an issue with incorrect call stack recordings that show the variables passed to a step in their state at the end of the pipeline execution (e.g. global vars to the pipeline). Also added a test example to exercise this.

I also have an example pipeline here that shows the issue:
https://github.com/macg33zr/pipelineUnit/blob/master/exampleJobs/globalVariable/Jenkinsfile