### PR TITLE
Replace time and object hash before comparing call stack for regression

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -29,7 +29,7 @@ class RegressionTestHelper {
             writeStackToFile(referenceFile, helper)
         }
 
-        String callStack = prepareCallStack(helper.callStack)
+        String callStack = prepareCallStack(helper.callStack) + System.lineSeparator()
         assertThat(callStack.normalize())
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
                         .isEqualTo(referenceFile.text.normalize())
@@ -42,7 +42,7 @@ class RegressionTestHelper {
         }
         String callStack = prepareCallStack(helper.callStack)
         referenceFile.withWriter { out ->
-            out.print(callStack)
+            out.println(callStack)
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -50,6 +50,7 @@ class RegressionTestHelper {
         return callStack.join(System.lineSeparator())
                     .replaceAll(/(\d{2}:\d{2}:\d+)/, '%TIME%')
                     .replaceAll(/([@][0-9a-f]+)/, '%HASH%')
+                    .replaceAll(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/, '%UUID%')
     }
 
     /**

--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -29,7 +29,7 @@ class RegressionTestHelper {
             writeStackToFile(referenceFile, helper)
         }
 
-        String callStack = helper.callStack.join('\n') + '\n'
+        String callStack = prepareCallStack(helper.callStack)
         assertThat(callStack.normalize())
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
                         .isEqualTo(referenceFile.text.normalize())
@@ -40,11 +40,16 @@ class RegressionTestHelper {
         if (!new File(referenceFile.parent).exists()) {
             new File(referenceFile.parent).mkdirs()
         }
+        String callStack = prepareCallStack(helper.callStack)
         referenceFile.withWriter { out ->
-            helper.callStack.each {
-                out.println(it)
-            }
+            out.print(callStack)
         }
+    }
+
+    private static String prepareCallStack(def callStack) {
+        return callStack.join(System.lineSeparator())
+                    .replaceAll(/(\d{2}:\d{2}:\d+)/, '%TIME%')
+                    .replaceAll(/([@][0-9a-f]+)/, '%HASH%')
     }
 
     /**

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
@@ -34,4 +34,11 @@ class TestRegression extends BaseRegressionTestCPS {
         super.testNonRegression("example")
     }
 
+    @Test
+    void testNonRegWithReplacements() throws Exception {
+        def script = runScript("job/exampleJobReg.jenkins")
+        script.execute()
+        super.testNonRegression("exampleJobReg")
+    }
+
 }

--- a/src/test/jenkins/job/exampleJobReg.jenkins
+++ b/src/test/jenkins/job/exampleJobReg.jenkins
@@ -1,0 +1,11 @@
+import java.util.UUID
+
+def execute() {
+    node() {
+        sh "Testing random UUID ${UUID.randomUUID()}"
+        sh "[${new Date().format("HH:mm:SS")}] log message with time"
+        sh "And hash ${new Object()}"
+    }
+}
+
+return this

--- a/src/test/resources/callstacks/TestRegression_exampleJobReg.txt
+++ b/src/test/resources/callstacks/TestRegression_exampleJobReg.txt
@@ -1,0 +1,6 @@
+   exampleJobReg.run()
+   exampleJobReg.execute()
+      exampleJobReg.node(groovy.lang.Closure)
+         exampleJobReg.sh(Testing random UUID %UUID%)
+         exampleJobReg.sh([%TIME%] log message with time)
+         exampleJobReg.sh(And hash java.lang.Object%HASH%)


### PR DESCRIPTION
Some of our pipelines add the current time to log messages. This causes regression tests to fail, as the time value will always be different. 

We're also sometimes passing objects that don't have a `toString()` method implemented. This also causes regression failures, because the object id changes each time.

This simple change addresses this, by replacing certain patterns with a fixed value, more specifically:
- `(\d{2}:\d{2}:\d+)` -> `%TIME%`
- `([@][0-9a-f]+)` -> `%HASH%`
- `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `%UUID%`

Example before:
```
lib-something.echo([MyTest] [08:33:22] [INFO] Hello World)
lib-something.doStuff(mypackage.LogHelper@12f3ab)
```
Example after:
```
lib-something.echo([MyTest] [%TIME%] [INFO] Hello World)
lib-something.doStuff(mypackage.LogHelper%HASH%)
```