### PR TITLE
Allow to mock custom pipeline methods using registerAllowedMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can redefine them as you wish.
 
 ### Mock Jenkins commands
 
-You can register interceptors to mock Jenkins commands, which may or may not return a result.
+You can register interceptors to mock pipeline methods, including Jenkins commands, which may or may not return a result.
 
 ```groovy
     @Override
@@ -141,6 +141,9 @@ You can register interceptors to mock Jenkins commands, which may or may not ret
         helper.registerAllowedMethod("timestamps", [], { println 'Printing timestamp' })
         helper.registerAllowedMethod(method("readFile", String.class), { file ->
             return Files.contentOf(new File(file), Charset.forName("UTF-8"))
+        })
+        helper.registerAllowedMethod("customMethodWithArguments", [String, int, Collection], { String stringArg, int intArg, Collection collectionArg ->
+            return println "executing mock closure with arguments (arguments: '${stringArg}', '${intArg}', '${collectionArg}')"
         })
     }
 ```

--- a/src/test/groovy/com/lesfurets/jenkins/TestCustomMethodJob.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestCustomMethodJob.groovy
@@ -1,0 +1,75 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.assertTrue
+
+class TestCustomMethodJob extends BasePipelineTest {
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+    }
+
+    @Test
+    void should_run_script_with_custom_method() {
+        // when:
+        runScript("job/customMethod.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing custom method closure')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_mock() {
+        // given:
+        Closure customMethodMock = { echo 'executing mock closure' }
+        helper.registerAllowedMethod('customMethod', [], customMethodMock)
+
+        // when:
+        runScript("job/customMethod.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing mock closure')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_with_arguments() {
+        // when:
+        runScript("job/customMethodWithArguments.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing custom method with arguments closure (arguments: \'stringArg\', \'42\', \'[collectionArg, 42]\')')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_with_arguments_mock() {
+        // given:
+        Closure customMethodWithArgumentsMock = { String stringArg, int intArg, Collection collectionArg ->
+            echo "executing mock closure with arguments (arguments: '${stringArg}', '${intArg}', '${collectionArg}')"
+        }
+        helper.registerAllowedMethod('customMethodWithArguments', [String, int, Collection], customMethodWithArgumentsMock)
+
+        // when:
+        runScript("job/customMethodWithArguments.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing mock closure with arguments (arguments: \'stringArg\', \'42\', \'[collectionArg, 42]\')')
+    }
+}

--- a/src/test/groovy/com/lesfurets/jenkins/TestCustomMethodJobCPS.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestCustomMethodJobCPS.groovy
@@ -1,0 +1,75 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.cps.BasePipelineTestCPS
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.assertTrue
+
+class TestCustomMethodJobCPS extends BasePipelineTestCPS {
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+    }
+
+    @Test
+    void should_run_script_with_custom_method() {
+        // when:
+        runScript("job/customMethod.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing custom method closure')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_mock() {
+        // given:
+        Closure customMethodMock = { echo 'executing mock closure' }
+        helper.registerAllowedMethod('customMethod', [], customMethodMock)
+
+        // when:
+        runScript("job/customMethod.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing mock closure')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_with_arguments() {
+        // when:
+        runScript("job/customMethodWithArguments.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing custom method with arguments closure (arguments: \'stringArg\', \'42\', \'[collectionArg, 42]\')')
+    }
+
+    @Test
+    void should_run_script_with_custom_method_with_arguments_mock() {
+        // given:
+        Closure customMethodWithArgumentsMock = { String stringArg, int intArg, Collection collectionArg ->
+            echo "executing mock closure with arguments (arguments: '${stringArg}', '${intArg}', '${collectionArg}')"
+        }
+        helper.registerAllowedMethod('customMethodWithArguments', [String, int, Collection], customMethodWithArgumentsMock)
+
+        // when:
+        runScript("job/customMethodWithArguments.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        assertTrue(helper.callStack.find { call ->
+            call.methodName == 'echo'
+        }.argsToString() == 'executing mock closure with arguments (arguments: \'stringArg\', \'42\', \'[collectionArg, 42]\')')
+    }
+}

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -7,12 +7,15 @@ class PipelineTestHelperTest {
 
     @Test
     void testRegisterAllowedMethodWithoutArgs() {
+        // given:
         def helper = new PipelineTestHelper()
-        def closure = { println 'withoutArgs'}
+        def closure = { println 'withoutArgs' }
         helper.registerAllowedMethod('withoutArgs', closure)
 
+        // when:
         Map.Entry<MethodSignature, Closure> allowedMethodEntry = helper.getAllowedMethodEntry('withoutArgs')
 
+        // then:
         Assertions.assertThat(allowedMethodEntry.getKey().getArgs().size()).isEqualTo(0)
         Assertions.assertThat(allowedMethodEntry.getValue()).isEqualTo(closure)
     }
@@ -21,7 +24,7 @@ class PipelineTestHelperTest {
     void testRegisterAllowedMethodEmptyArgs() {
         // given:
         def helper = new PipelineTestHelper()
-        def closure = { println 'emptyArgsList'}
+        def closure = { println 'emptyArgsList' }
         helper.registerAllowedMethod('emptyArgsList', closure)
 
         // when:

--- a/src/test/jenkins/job/customMethod.jenkins
+++ b/src/test/jenkins/job/customMethod.jenkins
@@ -1,0 +1,7 @@
+node() {
+    customMethod()
+}
+
+def customMethod() {
+    echo 'executing custom method closure'
+}

--- a/src/test/jenkins/job/customMethodWithArguments.jenkins
+++ b/src/test/jenkins/job/customMethodWithArguments.jenkins
@@ -1,0 +1,7 @@
+node() {
+    customMethodWithArguments('stringArg', 42, ['collectionArg', 42])
+}
+
+def customMethodWithArguments(String arg1, int arg2, Collection arg3) {
+    echo "executing custom method with arguments closure (arguments: '${arg1}', '${arg2}', '${arg3}')" as String
+}


### PR DESCRIPTION
Allow to use `registerAllowedMethod` from `PipelineTestHelper` to mock any pipeline method as  
expressed in https://github.com/jenkinsci/JenkinsPipelineUnit/issues/108