### PR TITLE
Add some dummy values to currentBuild

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -75,7 +75,28 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("withCredentials", [List.class, Closure.class], withCredentialsInterceptor)
         helper.registerAllowedMethod("error", [String.class], { updateBuildStatus('FAILURE') })
 
-        binding.setVariable('currentBuild', [result: 'SUCCESS'])
+        binding.setVariable('currentBuild', [
+            absoluteUrl: 'http://example.com/dummy',
+            buildVariables: [:],
+            changeSets: [],
+            currentResult: 'SUCCESS',
+            description: 'dummy',
+            displayName: '#1',
+            duration: 1,
+            durationString: '1 ms',
+            fullDisplayName: 'dummy #1',
+            fullProjectName: 'dummy',
+            id: '1',
+            keepLog: false,
+            nextBuild: null,
+            number: 1,
+            previousBuild: null,
+            projectName: 'dummy',
+            result: 'SUCCESS',
+            startTimeInMillis: 1,
+            timeInMillis: 1,
+            upstreamBuilds: [],
+        ])
     }
 
     /**


### PR DESCRIPTION
Jenkins' documentation for currentBuild says that at least some of
these properties will never be null. At any rate, it is nice to fill
in most of these with default dummy values so that Jenkinsfiles which
utilize the currentBuild properties do not fail tests.

Users can of course overwrite these properties by using
binding.setVariable() should they so choose.