### PR TITLE
Add missing inputs to the incremental task "test"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ task copyGrapesDependencies(type: CopyDependenciesToMavenTreeTask) {
 test.dependsOn copyGrapesDependencies
 
 test {
+    inputs.files ("$projectDir/src/test/jenkins", "$projectDir/grapeConfig.xml")
     systemProperty "grape.config", "$projectDir/grapeConfig.xml"
     systemProperty "grape.home", file("$buildDir/grapes").toURI()
     // Settings for debugging @Grape() resolution in test cases


### PR DESCRIPTION
This pull request fixes the specification of the gradle task test.
This task depends on some test resources that are located in the `src/test/jenkins` directory.


This commit considers this directory as inputs of this task so that tests are triggered whenever there are updates to any of the dependent test resources.