### PR TITLE
Add import statement for using the library() class

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ This pipeline is using a shared library called `commons`.
 Now let's test it:
 
 ```groovy
+// You need to import the class first
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+
     String clonePath = 'path/to/clone'
 
     def library = library()


### PR DESCRIPTION
When trying to use the library() class to import a shared library I kept getting an error saying the class was not available.  I figured it was in the `import com.lesfurets.jenkins.unit.*` statement, but after looking at the example [here](https://github.com/jenkinsci/JenkinsPipelineUnit/blob/master/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryWithProjectSourceRetriever.groovy) I noticed that it was in a separate path and needed to be imported as well.

I noticed under the SourceRetriever section it mentions you need to import those so I thought adding the import for the library() class would also be helpful to have in the readme.

Thanks.