### PR TITLE
retry mock should actually retry

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -130,9 +130,20 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("properties", [List])
         helper.registerAllowedMethod("pwd", [], { 'workspaceDirMocked' })
         helper.registerAllowedMethod("readFile", [String])
-        helper.registerAllowedMethod('retry', [Integer, Closure], { Integer count, Closure c ->
-            c.delegate = delegate
-            helper.callClosure(c)
+        helper.registerAllowedMethod("retry", [Integer, Closure], { Integer count, Closure c ->
+            def attempts = 0
+            while (attempts != count) {
+                try {
+                    attempts++
+                    c.delegate = delegate
+                    helper.callClosure(c)
+                    break
+                } catch(err) {
+                    if (attempts == count) {
+                        throw err
+                    }
+                }
+            }
         })
         helper.registerAllowedMethod("sh", [String])
         helper.registerAllowedMethod('sh', [Map], {m->

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -132,7 +132,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("readFile", [String])
         helper.registerAllowedMethod("retry", [Integer, Closure], { Integer count, Closure c ->
             def attempts = 0
-            while (attempts != count) {
+            while (attempts <= count) {
                 try {
                     attempts++
                     c.delegate = delegate


### PR DESCRIPTION
Make `retry` work as expected.

Given a Jenkinsfile like:

```groovy
node {
  retry(3) {
    closureUnderTest()
  }
}
```

I could write a test like:

```groovy
    @Test
    void testEventuallySucceeds() throws Exception {
        binding.setVariable('succeedAfterAttempts', 2)
        helper.registerAllowedMethod('closureUnderTest', [], {
            if (succeedAfterAttempts == 0 ) {
                echo "success"
            } else {
                succeedAfterAttempts--
                error "failure"
            }
        })
        executeScript('retryExample.jenkins')
```