### PR TITLE
Issue #209 - re-expose assertj-core API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "com.jfrog.artifactory" version "4.11.0"
     id 'groovy'
     id 'maven-publish'
-    id 'java'
+    id 'java-library'
     id 'jacoco'
     id 'net.researchgate.release' version '2.8.1'
 }
@@ -35,10 +35,9 @@ dependencies {
     implementation('com.cloudbees:groovy-cps:1.12')
     implementation('commons-io:commons-io:2.5')
     implementation('org.apache.ivy:ivy:2.4.0')
-    implementation('org.assertj:assertj-core:3.4.1')
+    api('org.assertj:assertj-core:3.4.1')
     implementation('org.apache.commons:commons-lang3:3.5')
 
-    testImplementation('org.assertj:assertj-core:3.4.1')
     testImplementation('junit:junit:4.11')
 
     grape('org.apache.commons:commons-math3:3.4.1')


### PR DESCRIPTION
Version 1.4 bumped the Gradle wrapper from version 4 to 5 (5ee10f8).
Gradle 5 deprecates and changes the semantics of `implementation` and
dependencies when publishing the POM to a Maven repository, turning
those dependency scopes from `compile` to `runtime`.

That means any project using JPU no longer has automatic access to
its `implementation` dependency APIs and must itself redeclare a
dependency on the JPU dependency in question when the project never
needed to before.

`assertj-core` is one such popular depenendency which should
be transitively exposed.

Gradle has an easy solution, the `api` dependency type provided by
the Java Library plugin. An added benefit is that JPU no longer
needs a second declaration of `assertj-core` for its own testing.