### PR TITLE
Added support for missing post conditions

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -232,6 +232,18 @@ abstract class BasePipelineTest {
     }
 
     /**
+     * Adds a previous build and sets the previous build status.
+     * Can be useful when mocking a jenkins method.
+     * @param status job status to set for previous build.
+     */
+    void addPreviousBuild(String status) {
+        binding.getVariable('currentBuild').id = 2
+        binding.getVariable('currentBuild').number = 2
+        binding.getVariable('currentBuild').previousBuild = [id: 1, number: 1, result: status]
+        println("previousBuild: ${ binding.getVariable('currentBuild').previousBuild}")
+    }
+
+    /**
      * Loads without running the script by its name/path, returning the Script
      * @param scriptName script name or path
      * @return script object

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -10,6 +10,7 @@ class PostDeclaration {
     Closure unstable
     Closure failure
     Closure aborted
+    Closure unsuccessful
 
     def always(Closure closure) {
         this.always = closure
@@ -25,6 +26,10 @@ class PostDeclaration {
 
     def unstable(Closure closure) {
         this.unstable = closure
+    }
+    
+    def unsuccessful(Closure closure) {
+        this.unsuccessful = closure
     }
 
     def failure(Closure closure) {
@@ -56,6 +61,9 @@ class PostDeclaration {
                 break
             case 'CHANGED':
                 executeOn(delegate, this.changed)
+                break
+            case 'UNSUCCESSFUL':
+                executeOn(delegate, this.unsuccessful)
                 break
         }
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -11,6 +11,9 @@ class PostDeclaration {
     Closure failure
     Closure aborted
     Closure unsuccessful
+    Closure cleanup
+    Closure fixed
+    Closure regression
 
     def always(Closure closure) {
         this.always = closure
@@ -40,8 +43,21 @@ class PostDeclaration {
         this.aborted = closure
     }
 
+    def cleanup(Closure closure) {
+        this.cleanup = closure
+    }
+
+    def fixed(Closure closure) {
+        this.fixed = closure
+    }
+
+    def regression(Closure closure){
+        this.regression = closure
+    }
+
     def execute(Object delegate) {
         def currentBuild = delegate.currentBuild.result
+        def previousBuild = delegate.currentBuild?.previousBuild?.result
         if (this.always) {
             executeOn(delegate, this.always)
         }
@@ -59,12 +75,32 @@ class PostDeclaration {
             case 'UNSTABLE':
                 executeOn(delegate, this.unstable)
                 break
-            case 'CHANGED':
-                executeOn(delegate, this.changed)
-                break
-            case 'UNSUCCESSFUL':
-                executeOn(delegate, this.unsuccessful)
-                break
+        }
+
+        if(currentBuild != previousBuild && this.changed)
+        {
+            executeOn(delegate, this.changed)
+        }
+        if(currentBuild != 'SUCCESS' && this.unsuccessful)
+        {
+            executeOn(delegate, this.unsuccessful)
+        }
+        if(this.fixed){
+            if(currentBuild == 'SUCCESS' && (previousBuild == 'FAILURE' || previousBuild == 'UNSTABLE'))
+            {
+                executeOn(delegate, this.fixed)
+            }
+        }
+        if(this.regression)
+        {
+            if((currentBuild == 'FAILURE' || currentBuild == 'UNSTABLE') && previousBuild == 'SUCCESS'){
+                executeOn(delegate, this.regression)
+            }
+        }
+
+        // Cleanup is always performed last
+        if(this.cleanup){
+            executeOn(delegate, this.cleanup)
         }
     }
 

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -18,6 +18,8 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         printCallStack()
         assertCallStackContains('pipeline unit tests PASSED')
         assertCallStackContains('pipeline unit tests completed')
+        assertCallStackContains('pipeline unit tests post CLEANUP')
+        assertCallStack().doesNotContain('pipeline unit tests UNSUCCESSFUL')
         assertJobStatusSuccess()
     }
 
@@ -30,6 +32,8 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusFailure()
         assertCallStack()
         assertCallStack().contains('pipeline unit tests FAILED')
+        assertCallStackContains('pipeline unit tests post CLEANUP')
+        assertCallStack().contains('pipeline unit tests UNSUCCESSFUL')
         assertCallStackContains('pipeline unit tests completed')
     }
 
@@ -42,18 +46,44 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusAborted()
         assertCallStack()
         assertCallStack().contains('pipeline unit tests ABORTED')
+        assertCallStackContains('pipeline unit tests post CLEANUP')
+        assertCallStack().contains('pipeline unit tests UNSUCCESSFUL')
         assertCallStackContains('pipeline unit tests completed')
     }
 
-    @Test void jenkinsfile_unsuccessful() throws Exception {
+    @Test void jenkinsfile_fixed() throws Exception {
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
-            updateBuildStatus('UNSUCCESSFUL')
+            addPreviousBuild('FAILURE')
+            updateBuildStatus('SUCCESS')
         })
         runScript('Declarative_Jenkinsfile')
         printCallStack()
+        assertJobStatusSuccess()
         assertCallStack()
-        assertCallStack().contains('pipeline unit tests UNSUCCESSFUL')
+        assertCallStackContains('pipeline unit tests PASSED')
         assertCallStackContains('pipeline unit tests completed')
+        assertCallStackContains('pipeline unit tests post CLEANUP')
+        assertCallStackContains('pipeline unit tests results have CHANGED')
+        assertCallStackContains('pipeline unit tests have been FIXED')
+    }
+
+    @Test void jenkinsfile_regression() throws Exception {
+        helper.registerAllowedMethod('sh', [String.class], { String cmd ->
+            addPreviousBuild('SUCCESS')
+            updateBuildStatus('UNSTABLE')
+        })
+        runScript('Declarative_Jenkinsfile')
+        printCallStack()
+        assertJobStatusUnstable()
+        assertCallStack()
+
+        assertCallStackContains('pipeline unit tests completed')
+        assertCallStackContains('pipeline unit tests have gone UNSTABLE')
+        assertCallStackContains('pipeline unit tests results have CHANGED')
+        assertCallStackContains('pipeline unit tests UNSUCCESSFUL')
+        assertCallStackContains('pipeline unit tests post REGRESSION')
+        assertCallStackContains('pipeline unit tests post CLEANUP')
+
     }
 
     @Test void should_params() throws Exception {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -1,7 +1,5 @@
 package com.lesfurets.jenkins.unit.declarative
 
-import static org.assertj.core.api.Assertions.*
-
 import org.junit.Before
 import org.junit.Test
 
@@ -44,6 +42,17 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusAborted()
         assertCallStack()
         assertCallStack().contains('pipeline unit tests ABORTED')
+        assertCallStackContains('pipeline unit tests completed')
+    }
+
+    @Test void jenkinsfile_unsuccessful() throws Exception {
+        helper.registerAllowedMethod('sh', [String.class], { String cmd ->
+            updateBuildStatus('UNSUCCESSFUL')
+        })
+        runScript('Declarative_Jenkinsfile')
+        printCallStack()
+        assertCallStack()
+        assertCallStack().contains('pipeline unit tests UNSUCCESSFUL')
         assertCallStackContains('pipeline unit tests completed')
     }
 

--- a/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
@@ -82,5 +82,17 @@ pipeline {
             echo 'pipeline unit tests UNSUCCESSFUL'
         }
 
+        fixed {
+            echo 'pipeline unit tests have been FIXED'
+        }
+
+        regression{
+            echo 'pipeline unit tests post REGRESSION'
+        }
+
+        cleanup {
+            echo 'pipeline unit tests post CLEANUP'
+        }
+
     }
 }

--- a/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Declarative_Jenkinsfile
@@ -78,5 +78,9 @@ pipeline {
             echo 'pipeline unit tests have gone UNSTABLE'
         }
 
+        unsuccessful {
+            echo 'pipeline unit tests UNSUCCESSFUL'
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #225 
Fixes #213

- Added support for missing post declarative conditionals. 
- Updated the functionality of 'CHANGED'. It was previously driven off of setting a build status of 'CHANGED' which is not a valid build status. 
- Added the ability to set the status of the previous build.
- Added additional tests to validate declarative postconditions.

**Useful Info**
- [Supported declarative post conditionals](https://www.jenkins.io/doc/book/pipeline/syntax/#post)
- [Jenkins build results](https://javadoc.jenkins-ci.org/hudson/model/Result.html)