### PR TITLE
Fix to parallel to return results

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -126,6 +126,9 @@ class PipelineTestHelper {
         // Since here the parallel steps are executed sequentially, we are hiding the error to let other steps run
         // and we make the job failing at the end.
         List<String> exceptions = []
+
+        Map results[:]
+
         m.entrySet().stream()
                         .filter { Map.Entry<String, Closure> entry -> entry.key != 'failFast' }
                         .forEachOrdered { Map.Entry<String, Closure> entry ->
@@ -138,11 +141,16 @@ class PipelineTestHelper {
                 delegate.binding.currentBuild.result = 'FAILURE'
                 exceptions.add("$parallelName - ${e.getMessage()}")
             }
+
+            results[parallelName] = result
+
             return result
         }
         if (exceptions) {
             throw new RuntimeException(exceptions.join(','))
         }
+
+        return results
     }
 
     /**


### PR DESCRIPTION
Hi,

This pull request attempts to parallel method interceptor so that it returns a dictionary with the results of each closure call, just like the real parallel step does.

Let me know if there's anything else to be added here.