### PR TITLE
Issue #224 support lazy library class loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,55 @@ Test class example:
     loadScript("job/library/exampleJob.jenkins")
     printCallStack()
 ```
+
+### Library global variables accepting library class instances as arguments: troubleshooting
+You might have a library defining global variables that implement custom steps
+accepting library class instances as arguments. For example consider the
+following library class and global variable.
+
+```groovy
+package org.test
+
+class Monster1 {
+    String moniker
+
+    Monster1(String m) {
+      moniker = m
+    }
+}
+```
+
+```groovy
+import org.test.Monster1
+
+void call(Monster1 m1) {
+    echo "$m1.moniker is always very scary"
+}
+```
+
+Your pipeline uses both as follows.
+```groovy
+vampire = new Monster1("Dracula")
+monster1(vampire)
+
+//Expect "Dracula is always very scary"
+```
+
+If this does not yield the expected output but instead throws a
+`MissingMethodException` with the cause `No signature of method:
+JENKINSFILE.monster1() is applicable for argument types: (org.test.Monster1)
+values: [org.test.Monster1@45f50182]` you may need to disable library class
+preload in your testing. You can do so in your test setup via the following
+switch.
+
+```groovy
+helper.libLoader.preloadLibraryClasses = false
+```
+
+You may need to do this for on a test-by-test basis as disabling class preload
+can cause problems in other use cases. For example, when you have library
+classes that require access to the `env` global.
+
 ## Note on CPS
 
 If you already fiddled with Jenkins pipeline DSL, you experienced strange errors during execution on Jenkins.

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -82,7 +82,7 @@ class PipelineTestHelper {
     /**
      * Loader for shared global libraries
      */
-    protected LibraryLoader libLoader
+    LibraryLoader libLoader
 
     /** Let scripts and library classes access global vars (env, currentBuild) */
     protected Binding binding

--- a/src/test/groovy/com/lesfurets/jenkins/TestInterceptingGCLLazyLoadLibClasses.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestInterceptingGCLLazyLoadLibClasses.groovy
@@ -1,0 +1,59 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.LibClassLoader
+import com.lesfurets.jenkins.unit.BasePipelineTest
+
+import org.junit.Before
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+
+class TestInterceptingGCLLazyLoadLibClasses extends BasePipelineTest {
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+        helper.libLoader.preloadLibraryClasses = false
+    }
+
+    /**
+    * 1. Load two libraries--one dependent on the other--with implicity
+    * 2. Create instance of library class and pass instance to library vars step
+    * 3. That vars step in turn creates instance of another library class
+    *    and passes it to another library step
+    * 4. Make sure interception of pipeline methods works propertly
+    */
+    @Test
+    void test_cross_class_as_var_arg_implicit_lazy_load() throws Exception {
+        //This does not factor much in the current test but does replicate the
+        //use case in which the lazy load feature originated.
+        helper.cloneArgsOnMethodCallRegistration = false
+
+        //test_cross_class_as_var_arg_1 uses vars and classes in
+        //test_cross_class_as_var_arg_2 so the latter has to be loaded first
+        [
+            "test_cross_class_as_var_arg_2",
+            "test_cross_class_as_var_arg_1",
+        ].each { libName ->
+            final libDir = this.class.getResource("/libs/$libName").file
+            final library = library().name(libName)
+                                     .defaultVersion("master")
+                                     .allowOverride(false)
+                                     .implicit(true)
+                                     .targetPath(libDir)
+                                     .retriever(projectSource(libDir))
+                                     .build()
+            helper.registerSharedLibrary(library)
+        }
+
+        final pipeline = "test_var_with_lib_class_arg"
+        runScript("job/library/cross_class_lazy_load/${pipeline}.jenkins")
+        printCallStack()
+        assertCallStackContains("""${pipeline}.monster1(org.test.Monster1""")
+        assertCallStackContains("""monster1.monster2(org.test.extra.Monster2""")
+        assertCallStackContains("""monster2.echo(Frankenstein's Monster all by itself is frightening)""")
+        assertCallStackContains("""monster1.echo(Dracula and Frankenstein's Monster make quite a scary team)""")
+    }
+}

--- a/src/test/jenkins/job/library/cross_class_lazy_load/test_var_with_lib_class_arg.jenkins
+++ b/src/test/jenkins/job/library/cross_class_lazy_load/test_var_with_lib_class_arg.jenkins
@@ -1,0 +1,7 @@
+@Library("test_cross_class_as_var_arg_2")
+import org.test.extra.Monster2
+@Library("test_cross_class_as_var_arg_1")
+import org.test.Monster1
+
+vampire = new Monster1("Dracula")
+monster1(vampire)

--- a/src/test/resources/libs/test_cross_class_as_var_arg_1/src/org/test/Monster1.groovy
+++ b/src/test/resources/libs/test_cross_class_as_var_arg_1/src/org/test/Monster1.groovy
@@ -1,0 +1,9 @@
+package org.test
+
+class Monster1 {
+    String moniker
+
+    Monster1(String m) {
+      moniker = m
+    }
+}

--- a/src/test/resources/libs/test_cross_class_as_var_arg_1/vars/monster1.groovy
+++ b/src/test/resources/libs/test_cross_class_as_var_arg_1/vars/monster1.groovy
@@ -1,0 +1,8 @@
+import org.test.Monster1
+import org.test.extra.Monster2
+
+void call(Monster1 m1) {
+    final m2 = new Monster2("Frankenstein's Monster")
+    monster2 m2
+    echo "$m1.moniker and $m2.moniker make quite a scary team"
+}

--- a/src/test/resources/libs/test_cross_class_as_var_arg_2/src/org/test/extra/Monster2.groovy
+++ b/src/test/resources/libs/test_cross_class_as_var_arg_2/src/org/test/extra/Monster2.groovy
@@ -1,0 +1,9 @@
+package org.test.extra
+
+class Monster2 {
+    String moniker
+    
+    Monster2(String m) {
+        moniker = m
+    }
+}

--- a/src/test/resources/libs/test_cross_class_as_var_arg_2/vars/monster2.groovy
+++ b/src/test/resources/libs/test_cross_class_as_var_arg_2/vars/monster2.groovy
@@ -1,0 +1,5 @@
+import org.test.extra.Monster2
+
+void call(Monster2 m2) {
+    echo "$m2.moniker all by itself is frightening"
+}


### PR DESCRIPTION
v1.4 introduced the preload of shared library classes alongside the
existing preload of vars (ie custom steps).

In most use cases this is ideal. However in some use cases library
steps that use library classes in their call arguments are subject
to mistaken `MissingMethodException` errors when those classes are
preloaded. The method interceptor becomes confused because at some
point the same types are loaded more that once, and the argument
passed to the interceptor appears to be of a different type than
the type registered in the interceptor.

In those use cases the pre-v1.4 behavior of lazy loading the library
classes is helpful. The new `LibraryLoader.preloadLibraryClasses`
property can be set by the test to disable the class preload.