### PR TITLE
Add mocks for docker singleton

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -257,6 +257,7 @@ abstract class BasePipelineTest {
             timeInMillis: 1,
             upstreamBuilds: [],
         ])
+        binding.setVariable('docker', new DockerMock())
         binding.setVariable('env',[:])
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/DockerMock.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/DockerMock.groovy
@@ -1,0 +1,77 @@
+package com.lesfurets.jenkins.unit
+
+
+@SuppressWarnings(['EmptyMethod', 'MethodReturnTypeRequired', 'UnusedMethodParameter'])
+class DockerMock implements Serializable {
+    class Container implements Serializable {
+        String id
+
+        Container(String id = 'mock-container') {
+            this.id = id
+        }
+
+        def port() {
+            return '1234'
+        }
+
+        def stop() {}
+    }
+
+    class Image implements Serializable {
+        String id
+        String tagname
+
+        Image(String id) {
+            this.id = id
+            this.tagname = 'latest'
+        }
+
+        def imageName() {
+            return id
+        }
+
+        def inside(String args = '', Closure body) {
+            return body(new Container())
+        }
+
+        def pull() {}
+
+        def push(String tagname = '') {
+            if (tagname) {
+                tag(tagname)
+            }
+        }
+
+        def run(String args = '', String command = '') {
+            return new Container()
+        }
+
+        def tag(String tagname = '') {
+            this.tagname = tagname
+        }
+
+        def withRun(String args = '', String command = '', Closure body) {
+            return body(new Container())
+        }
+    }
+
+    Image build(String image, String args = '') {
+        return new Image(image)
+    }
+
+    Image image(String id) {
+        return new Image(id)
+    }
+
+    void withRegistry(String url, String credentialsId = '', Closure body) {
+        body()
+    }
+
+    void withServer(String uri, String credentialsId = '', Closure body) {
+        body()
+    }
+
+    void withTool(String toolName, Closure body) {
+        body()
+    }
+}

--- a/src/test/groovy/com/lesfurets/jenkins/unit/TestDockerMock.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/TestDockerMock.groovy
@@ -1,0 +1,28 @@
+package com.lesfurets.jenkins.unit
+
+import org.junit.Before
+import org.junit.Test
+
+
+/**
+ * Test the DockerMock class
+ *
+ * It would be a bit redundant to write regular unit tests for DockerMock, because most of
+ * the methods are empty or void. So instead this test class loads a Jenkins pipeline file
+ * which exercises all of the methods of the docker singleton.
+ */
+class DockerMockTest extends BasePipelineTest {
+  Object script = null
+
+  @Before
+  @Override
+  void setUp() {
+    super.setUp()
+    this.script = loadScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
+  }
+
+  @Test
+  void executePipeline() throws Exception {
+    script.execute()
+  }
+}

--- a/src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile
@@ -1,0 +1,78 @@
+void execute() {
+  node {
+    String testImageName = 'test'
+
+    stage('Test docker.build()') {
+      def image = docker.build(testImageName)
+      assert image.id == testImageName
+    }
+
+    stage('Test docker.image()') {
+      def image = docker.image(testImageName)
+      assert image.id == testImageName
+    }
+
+    stage('Test docker.withRegistry') {
+      docker.withRegistry('test.registry', 'fake-credentials') {
+        def image = docker.image(testImageName)
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.withServer()') {
+      docker.withServer('test.server', 'fake-credentials') {
+        def image = docker.image(testImageName)
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.withTool()') {
+      docker.withTool('test-docker') {
+        def image = docker.image(testImageName)
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.image.imageName()') {
+      def image = docker.image(testImageName)
+      assert image.imageName() == testImageName
+    }
+
+    stage('Test docker.image.inside()') {
+      def image = docker.image(testImageName)
+      image.inside {
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.image.pull()') {
+      docker.image(testImageName).pull()
+    }
+
+    stage('Test docker.image.push()') {
+      def image = docker.image(testImageName)
+      image.push('test-tag')
+      assert image.tagname == 'test-tag'
+    }
+
+    stage('Test docker.image.run()') {
+      def container = docker.image(testImageName).run()
+      container.stop()
+    }
+
+    stage('Test docker.image.tag()') {
+      def image = docker.image(testImageName)
+      image.tag('test')
+      assert image.tagname == 'test'
+    }
+
+    stage('Test docker.image.withRun()') {
+      def image = docker.image(testImageName)
+      image.withRun {
+        assert image.id == testImageName
+      }
+    }
+  }
+}
+
+return this


### PR DESCRIPTION
Although this singleton is not part of the standard Jenkins pipeline
API, it is a frequently-used plugin and the addition of mocks for this
singleton have been requested by several users.

---

Closes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/242