### PR TITLE
Add mocks for isUnix, and pwd (when called with a Map)

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -155,6 +155,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod('pollSCM', [String])
         helper.registerAllowedMethod("properties", [List])
         helper.registerAllowedMethod("pwd", [], { 'workspaceDirMocked' })
+        helper.registerAllowedMethod("pwd", [Map], { 'tempDirMocked' })
         helper.registerAllowedMethod('readFile', [Map], { args -> helper.readFile(args )})
         helper.registerAllowedMethod('readFile', [String], { args -> helper.readFile(args )})
         helper.registerAllowedMethod("retry", [Integer, Closure], { Integer count, Closure c ->

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -140,6 +140,9 @@ abstract class BasePipelineTest {
             helper.callClosure(c)
         })
         helper.registerAllowedMethod("input", [String])
+        helper.registerAllowedMethod('isUnix', [], {
+            return !System.properties['os.name'].toLowerCase().contains('windows')
+        })
         helper.registerAllowedMethod("junit", [String])
         helper.registerAllowedMethod("library", [String], {String expression ->
             helper.getLibLoader().loadImplicitLibraries()


### PR DESCRIPTION
This PR adds a mock for the alternate signature of `pwd`, and also a mock of `isUnix` which returns the correct value for the given system that the tests are being run on.