### PR TITLE
Allow for mocking sh step output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,33 @@ You can take a look at the `BasePipelineTest` class to have the short list of al
 Some tricky methods such as `load` and `parallel` are implemented directly in the helper.
 If you want to override those, make sure that you extend the `PipelineTestHelper` class.
 
+### Mocking readFile
+
+The `readFile` step can be mocked to return a specific string for a given file name. This can be useful for testing
+pipelines which must read data from a file which is required for subsequent steps. An example of such a testing scenario
+follows:
+
+```groovy
+// Jenkinsfile
+node {
+    stage('Process output') {
+        if (readFile('output') == 'FAILED!!!') {
+            currentBuild.result = 'FAILURE'
+            error 'Build failed'
+        }
+    }
+}
+```
+
+```groovy
+@Test
+void exampleReadFileTest() {
+    helper.addReadFileMock('output', 'FAILED!!!')
+    runScript("Jenkinsfile")
+    assertJobStatusFailure()
+}
+```
+
 ### Analyze the mock execution
 
 The helper registers every method call to provide a stacktrace of the mock execution.

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -176,14 +176,8 @@ abstract class BasePipelineTest {
                 }
             }
         })
-        helper.registerAllowedMethod("sh", [String])
-        helper.registerAllowedMethod('sh', [Map], {m->
-          if(m.returnStdout && m.script.contains("git rev-parse HEAD")) {
-            return "abcd123\n"
-          } else {
-            return """aaa\nbbb\nccc\n"""
-          }
-        })
+        helper.registerAllowedMethod('sh', [String], { args -> helper.runSh(args) })
+        helper.registerAllowedMethod('sh', [Map], { args -> helper.runSh(args) })
         helper.registerAllowedMethod('skipDefaultCheckout')
         helper.registerAllowedMethod('sleep')
         helper.registerAllowedMethod('specific', [String])

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -23,6 +23,27 @@ class PipelineTestHelper {
     protected static Method SCRIPT_SET_BINDING = Script.getMethod('setBinding', Binding.class)
 
     /**
+     * Simple container for holding mock script output.
+     */
+    class MockScriptOutput {
+        String stdout = null
+        int exitValue = -1
+        Closure callback = null
+
+        MockScriptOutput(String stdout, int exitValue) {
+            this.stdout = stdout
+            this.exitValue = exitValue
+        }
+
+        MockScriptOutput(Closure callback) {
+            this.callback = callback
+        }
+    }
+
+    /** Holds configured mock output values for the `sh` command. */
+    Map<String, MockScriptOutput> mockScriptOutputs = [:]
+
+    /**
      * Search paths for scripts
      */
     String[] scriptRoots
@@ -277,6 +298,7 @@ class PipelineTestHelper {
         gse = new GroovyScriptEngine(scriptRoots, cLoader)
         gse.setConfig(configuration)
 
+        mockScriptOutputs.clear()
         mockReadFileOutputs.clear()
         return this
     }
@@ -551,6 +573,104 @@ class PipelineTestHelper {
         assert file
 
         return mockReadFileOutputs[file] ?: ''
+    }
+
+    /**
+     * Configure mock output for the `sh` command. This function should be called before
+     * attempting to call `JenkinsMocks.sh()`.
+     * @param script Script command to mock.
+     * @param stdout Standard output text to return for the given command.
+     * @param exitValue Exit value for the command.
+     */
+    void addShMock(String script, String stdout, int exitValue) {
+        mockScriptOutputs[script] = new MockScriptOutput(stdout, exitValue)
+    }
+
+    /**
+     * Configure mock callback for the `sh` command. This function should be called before
+     * attempting to call `JenkinsMocks.sh()`.
+     * @param script Script command to mock.
+     * @param callback Closure to be called when the mock is executed. This closure will be
+     *                 passed the script call which is being executed, and
+     *                 <strong>must</strong> return a {@code Map} with the following
+     *                 key/value pairs:
+     *                 <ul>
+     *                   <li>{@code stdout}: {@code String} with the mocked output.</li>
+     *                   <li>{@code exitValue}: {@code int} with the mocked exit value.</li>
+     *                 </ul>
+     */
+    void addShMock(String script, Closure callback) {
+        mockScriptOutputs[script] = new MockScriptOutput(callback)
+    }
+
+    @SuppressWarnings('ThrowException')
+    def runSh(def args) {
+        String script = null
+        boolean returnStdout = false
+        boolean returnStatus = false
+
+        // The `sh` function can be called with either a string, or a map of key/value pairs.
+        if (args instanceof String || args instanceof GString) {
+            script = args
+        } else if (args instanceof Map) {
+            script = args['script']
+            returnStatus = args['returnStatus'] ?: false
+            returnStdout = args['returnStdout'] ?: false
+            if (returnStatus && returnStdout) {
+                throw new IllegalArgumentException('returnStatus and returnStdout are mutually exclusive options')
+            }
+        }
+        assert script
+
+        MockScriptOutput output = mockScriptOutputs[script]
+        if (!output) {
+            // If no output is given, we return these strings for backwards-compatibility. Ideally at some point in the
+            // future, we should make a breaking change and remove this special use-case and either raise an exception
+            // here or return an empty string.
+            if(returnStdout && script.contains("git rev-parse HEAD")) {
+                return 'abcd123\n'
+            } else {
+                return '\nbbb\nccc\n'
+            }
+        }
+
+        String stdout
+        int exitValue
+
+        // If the callback closure is not null, execute it and grab the output.
+        if (output.callback) {
+            Map callbackOutput
+            try {
+                callbackOutput = output.callback(script)
+            } catch (GroovyCastException) {
+                throw new IllegalArgumentException("Mocked sh callback for ${script} was not a map")
+            }
+            if (!callbackOutput.containsKey('stdout') || !(callbackOutput['stdout'] instanceof String)) {
+                throw new IllegalArgumentException("Mocked sh callback for ${script} did not contain a valid value for the stdout key")
+            }
+            if (!callbackOutput.containsKey('exitValue') || !(callbackOutput['exitValue'] instanceof Integer)) {
+                throw new IllegalArgumentException("Mocked sh callback for ${script} did not contain a valid value for the exitValue key")
+            }
+            stdout = callbackOutput['stdout']
+            exitValue = callbackOutput['exitValue']
+        } else {
+            stdout = output.stdout
+            exitValue = output.exitValue
+        }
+
+        if (!returnStdout) {
+            println stdout
+        }
+
+        if (returnStdout) {
+            return stdout
+        }
+        if (returnStatus) {
+            return exitValue
+        }
+        if (exitValue != 0) {
+            throw new Exception('Script returned error code: ' + exitValue)
+        }
     }
 
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -73,4 +73,219 @@ class PipelineTestHelperTest {
         Assertions.assertThat(output).isEqualTo('')
     }
 
+    @Test
+    void runSh() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd', '/foo/bar', 0)
+
+        // when:
+        def output = helper.runSh('pwd')
+
+        // then:
+        Assertions.assertThat(output).isNull()
+    }
+
+    @Test(expected = Exception)
+    void runShWithScriptFailure() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('evil', '/foo/bar', 666)
+
+        // when:
+        helper.runSh('evil')
+
+        // then: Exception raised
+    }
+
+    @Test
+    void runShWithStdout() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd', '/foo/bar', 0)
+
+        // when:
+        def output = helper.runSh(returnStdout: true, script: 'pwd')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('/foo/bar')
+    }
+
+    @Test
+    void runShWithReturnCode() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd', '/foo/bar', 0)
+
+        // when:
+        def output = helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo(0)
+    }
+
+    @Test
+    void runShWithNonZeroReturnCode() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('evil', '/foo/bar', 666)
+
+        // when:
+        def output = helper.runSh(returnStatus: true, script: 'evil')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo(666)
+    }
+
+    @Test
+    void runShWithCallback() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [stdout: '/foo/bar', exitValue: 0]
+        }
+
+        // when:
+        def output = helper.runSh('pwd')
+
+        // then:
+        Assertions.assertThat(output).isNull()
+    }
+
+    @Test(expected = Exception)
+    void runShWithCallbackScriptFailure() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('evil') { script ->
+            return [stdout: '/foo/bar', exitValue: 666]
+        }
+
+        // when:
+        helper.runSh('evil')
+
+        // then: Exception raised
+    }
+
+    @Test
+    void runShWithCallbackStdout() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [stdout: '/foo/bar', exitValue: 0]
+        }
+
+        // when:
+        def output = helper.runSh(returnStdout: true, script: 'pwd')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('/foo/bar')
+    }
+
+    @Test
+    void runShWithCallbackReturnCode() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [stdout: '/foo/bar', exitValue: 0]
+        }
+
+        // when:
+        def output = helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo(0)
+    }
+
+    @Test
+    void runShWithCallbackNonZeroReturnCode() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [stdout: '/foo/bar', exitValue: 666]
+        }
+
+        // when:
+        def output = helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo(666)
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void runShWithCallbackOutputNotMap() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return 'invalid'
+        }
+
+        // when:
+        helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then: Exception raised
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void runShWithCallbackNoStdoutKey() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [exitValue: 666]
+        }
+
+        // when:
+        helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then: Exception raised
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void runShWithCallbackNoExitValueKey() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock('pwd') { script ->
+            return [stdout: '/foo/bar']
+        }
+
+        // when:
+        helper.runSh(returnStatus: true, script: 'pwd')
+
+        // then: Exception raised
+    }
+
+    @Test()
+    void runShWithoutMockOutput() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def output = helper.runSh('unregistered-mock-output')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('\nbbb\nccc\n')
+    }
+
+    @Test()
+    void runShWithoutMockOutputForGitRevParse() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def output = helper.runSh(returnStdout: true, script: 'git rev-parse HEAD')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('abcd123\n')
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void runShWithBothStatusAndStdout() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        helper.runSh(returnStatus: true, returnStdout: true, script: 'invalid')
+
+        // then: Exception raised
+    }
+
 }


### PR DESCRIPTION
The sh step is a bit special, because it is the workhorse of many
pipeline scripts. In many cases, users need to be able to test how a
pipeline behaves if a script fails, or if it returns some output that
is required as the input for subsequent steps.

This commit adds a new method to PipelineTestHelper called addShMock,
which accepts either a combination of an exit code and return value,
or a closure. In both cases, when the mocked sh step runs, it looks to
see if any output has been registered for the given script. If it
finds a match, it returns either the exit code and/or return value
(depending on the arguments given to the sh step), or executes the
closure and returns that value.

Note that for this feature to work, the mocked script call must
EXACTLY match the call made to the sh step. In other words, globs or
fuzzy matching of the script call is not yet supported.

If the sh step does not find a match for the given script, then the
old behavior is retained and a hardcoded "bbb\nccc\n" value is
returned, or a fake SHA1 value if the script call happened to be "git
rev-parse HEAD".

At some point in the future, I would like to remove this behavior, but
I felt it important to add this feature without introducing a breaking
change in order to give users of this framework time to adapt their
test cases.
