### PR TITLE
Allow for mocking readFile step output

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -155,7 +155,8 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod('pollSCM', [String])
         helper.registerAllowedMethod("properties", [List])
         helper.registerAllowedMethod("pwd", [], { 'workspaceDirMocked' })
-        helper.registerAllowedMethod("readFile", [String])
+        helper.registerAllowedMethod('readFile', [Map], { args -> helper.readFile(args )})
+        helper.registerAllowedMethod('readFile', [String], { args -> helper.readFile(args )})
         helper.registerAllowedMethod("retry", [Integer, Closure], { Integer count, Closure c ->
             def attempts = 0
             while (attempts <= count) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -87,6 +87,8 @@ class PipelineTestHelper {
     /** Let scripts and library classes access global vars (env, currentBuild) */
     protected Binding binding
 
+    Map<String, String> mockReadFileOutputs = [:]
+
     /**
     * Get library loader object
     *
@@ -274,6 +276,8 @@ class PipelineTestHelper {
 
         gse = new GroovyScriptEngine(scriptRoots, cLoader)
         gse.setConfig(configuration)
+
+        mockReadFileOutputs.clear()
         return this
     }
 
@@ -531,6 +535,22 @@ class PipelineTestHelper {
         } else {
             return closure.call(*args)
         }
+    }
+
+    void addReadFileMock(String file, String contents) {
+        mockReadFileOutputs[file] = contents
+    }
+
+    String readFile(def args) {
+        String file = null
+        if (args instanceof String || args instanceof GString) {
+            file = args
+        } else if (args instanceof Map) {
+            file = args['file']
+        }
+        assert file
+
+        return mockReadFileOutputs[file] ?: ''
     }
 
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -1,7 +1,7 @@
 package com.lesfurets.jenkins.unit
 
 import org.assertj.core.api.Assertions
-import org.junit.Test;
+import org.junit.Test
 
 class PipelineTestHelperTest {
 
@@ -33,6 +33,44 @@ class PipelineTestHelperTest {
         // then:
         Assertions.assertThat(allowedMethodEntry.getKey().getArgs().size()).isEqualTo(0)
         Assertions.assertThat(allowedMethodEntry.getValue()).isEqualTo(closure)
+    }
+
+    @Test
+    void readFile() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addReadFileMock('test', 'contents')
+
+        // when:
+        def output = helper.readFile('test')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('contents')
+    }
+
+    @Test
+    void readFileWithMap() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addReadFileMock('test', 'contents')
+
+        // when:
+        def output = helper.readFile(file: 'test')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('contents')
+    }
+
+    @Test
+    void readFileWithNoMockOutput() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def output = helper.readFile('test')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo('')
     }
 
 }


### PR DESCRIPTION
This commit adds a new method to PipelineTestHelper called
addReadFileMock, which allows one to specify the contents which should
be returned by a call to readFile. This is useful for testing
pipelines which read files (perhaps generated by a build step, are
fetched from a remote server, etc), and the contents of these files
influence subsequent build logic.

If the readFile mock is called by a pipeline without the unit test
having called addReadFileMock, then an empty string is returned.