### PR TITLE
Issue #260: Fix IllegalArgumentException with GlobalVar taking a single argument

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -454,7 +454,16 @@ class PipelineTestHelper {
                 SCRIPT_SET_BINDING.invoke(script, binding)
                 script.metaClass.getMethods().findAll { it.name == 'call' }.forEach { m ->
                     this.registerAllowedMethod(method(e.value.class.name, m.getNativeParameterTypes()),
-                                    { args -> m.doMethodInvoke(e.value, args) })
+                        { args ->
+                            // When calling a one argument method with a null argument the
+                            // Groovy doMethodInvoke appears to incorrectly assume a zero
+                            // argument call signature for the method yielding an IllegalArgumentException
+                            if (args == null && m.getNativeParameterTypes().size() == 1) {
+                                m.doMethodInvoke(e.value, MetaClassHelper.ARRAY_WITH_NULL)
+                            } else {
+                                m.doMethodInvoke(e.value, args)
+                            }
+                        })
                 }
             }
             binding.setVariable(e.key, e.value)

--- a/src/test/groovy/com/lesfurets/jenkins/TestOneArgumentJob.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestOneArgumentJob.groovy
@@ -1,0 +1,43 @@
+package com.lesfurets.jenkins
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.LocalSource.localSource
+
+import com.lesfurets.jenkins.unit.LibClassLoader
+import com.lesfurets.jenkins.unit.BaseRegressionTest
+import org.junit.Before
+import org.junit.Test
+
+import static org.junit.Assert.assertTrue
+
+class TestOneArgumentJob extends BaseRegressionTest {
+    
+    String sharedLibs = this.class.getResource('/libs').getFile()
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+        binding.setVariable('scm', [branch: 'master'])
+    }
+
+    @Test
+    void should_run_script_with_one_argument() {
+        def library = library().name('commons')
+                        .defaultVersion("master")
+                        .allowOverride(true)
+                        .implicit(false)
+                        .targetPath(sharedLibs)
+                        .retriever(localSource(sharedLibs))
+                        .build()
+        helper.registerSharedLibrary(library)
+
+        // when:
+        runScript("job/library/test_lib_call_with_null.jenkins")
+
+        // then:
+        assertJobStatusSuccess()
+        testNonRegression("should_run_script_with_one_argument")
+    }
+}

--- a/src/test/jenkins/job/library/test_lib_call_with_null.jenkins
+++ b/src/test/jenkins/job/library/test_lib_call_with_null.jenkins
@@ -1,0 +1,5 @@
+@Library('commons@feature') _
+
+// Test calling a one argument global with null
+oneArg('Not null')
+oneArg(null)

--- a/src/test/resources/callstacks/TestOneArgumentJob_should_run_script_with_one_argument.txt
+++ b/src/test/resources/callstacks/TestOneArgumentJob_should_run_script_with_one_argument.txt
@@ -1,0 +1,5 @@
+   test_lib_call_with_null.run()
+      test_lib_call_with_null.oneArg(Not null)
+         oneArg.echo(Is not null)
+      test_lib_call_with_null.oneArg(null)
+         oneArg.echo(Is null)

--- a/src/test/resources/libs/commons@feature/vars/oneArg.groovy
+++ b/src/test/resources/libs/commons@feature/vars/oneArg.groovy
@@ -1,8 +1,4 @@
 // file: vars/oneArg.groovy
 def call(arg) {
-    if (arg == null) {
-        echo "Is null"
-    } else {
-        echo "Is not null"
-    }
+    echo arg ? "Is not null" : "Is null"
 }

--- a/src/test/resources/libs/commons@feature/vars/oneArg.groovy
+++ b/src/test/resources/libs/commons@feature/vars/oneArg.groovy
@@ -1,0 +1,8 @@
+// file: vars/oneArg.groovy
+def call(arg) {
+    if (arg == null) {
+        echo "Is null"
+    } else {
+        echo "Is not null"
+    }
+}


### PR DESCRIPTION
When calling a GlovalVar declared to accept one argument and the caller
passes null to the function it yields an IllegalArgumentException
instead of passing the null argument. This is unique to single argument
method calls and appears rooted in the way Grrovy lang handles the
invocation when null is provided.

This fix was inspired from the code in the invoked Groovy methods.