### PR TITLE
Fix issue 249: Eliminate use of @Memoized

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -74,7 +74,7 @@ abstract class BasePipelineTest {
         if (!helper.isInitialized()) {
             initHelper()
         } else {
-            helper.callStack.clear()
+            clearCallStack()
         }
 
         registerAllowedMethods()
@@ -315,11 +315,30 @@ abstract class BasePipelineTest {
         return helper.runScript(script, this.binding)
     }
 
-    @Memoized
+    private String cachedStackDump = null
+
+    /**
+     * Clear the call stack in preparation to reuse this test helper.
+     */
+    void clearCallStack() {
+        helper.clearCallStack()
+        cachedStackDump = null
+    }
+
+    /**
+     * Compute and return the representation of the call stack captured.
+     * 
+     * @return the string containing the stack dump
+     */
     String callStackDump() {
-        return helper.callStack.stream()
+        // Avoid use of Memoized to support clearing the stack
+        // and reusing the instance of this helper class.
+        if (cachedStackDump == null) {
+            cachedStackDump = helper.callStack.stream()
                      .map { it -> it.toString() }
                      .collect(joining('\n'))
+        }
+        return cachedStackDump
     }
 
     void printCallStack() {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/MethodSignature.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/MethodSignature.groovy
@@ -21,13 +21,14 @@ class MethodSignature {
     String argsToString() {
         return args.collect { Class it ->
             if (it != null && Closure.isAssignableFrom(it)) {
-                Closure.class.toString()
+                Closure.class.getName()
             } else {
                 String.valueOf(it)
             }
         }.join(', ')
     }
 
+    @Override
     boolean equals(o) {
         if (this.is(o)) return true
         if (getClass() != o.class) return false
@@ -49,6 +50,7 @@ class MethodSignature {
         return true
     }
 
+    @Override
     int hashCode() {
         int result
         result = (name != null ? name.hashCode() : 0)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/GenericPipelineDeclaration.groovy
@@ -13,7 +13,7 @@ abstract class GenericPipelineDeclaration {
     static def binding = null
 
     static <T> T createComponent(Class<T> componentType,
-                                 @DelegatesTo(strategy = DELEGATE_ONLY, value = T) Closure closure) {
+                                 @DelegatesTo(strategy = DELEGATE_ONLY) Closure<T> closure) {
         def componentInstance = componentType.newInstance()
         def rehydrate = closure.rehydrate(componentInstance, this, this)
         rehydrate.resolveStrategy = DELEGATE_ONLY

--- a/src/test/groovy/com/lesfurets/jenkins/unit/CallStackDumpTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/CallStackDumpTest.groovy
@@ -1,0 +1,29 @@
+package com.lesfurets.jenkins.unit
+
+import org.junit.Test
+
+class CallStackDumpTest extends BasePipelineTest {
+
+    @Test
+    void test_callStackDump_returns_new_value() {
+        setUp()
+        def script = loadScript('src/test/jenkins/job/callStackDump.jenkins')
+        
+        // Call method1 and expect callstack to match
+        script.someMethod1()
+        assertCallStackContains('callStackDump.someMethod1()')
+
+        // Reset using setUp call
+        setUp()
+        // Call method2 and expect callstack to match
+        script.someMethod2()
+        assertCallStackContains('callStackDump.someMethod2()')
+        assertCallStack().doesNotContain('callStackDump.someMethod1()')
+        
+        // Reset using clearCallStack call
+        clearCallStack()
+        // Call method1 and expect callstack to match
+        script.someMethod1()
+        assertCallStackContains('callStackDump.someMethod1()')
+    }
+}

--- a/src/test/jenkins/job/callStackDump.jenkins
+++ b/src/test/jenkins/job/callStackDump.jenkins
@@ -1,0 +1,8 @@
+
+def someMethod1() {
+    'method1'
+}
+
+def someMethod2() {
+    'method2'
+}


### PR DESCRIPTION
Created a direct callable method `clearCallStack()` and removed the use of `@Memoized` to avoid problems with resetting the call stack between runs. The output is cached like it was with `@Memoized to avoid unnecessary overhead from repeated calls to assert call stack states.

Fixed two minor compilation issues that were found in Eclipse IDE. The code changes are minor but if there are objections to the changes I can remove the commit from the pull request.