### PR TITLE
Fix arguments processed by mocked closures

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -188,7 +188,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("step", [Map])
         helper.registerAllowedMethod("string", [Map], stringInterceptor)
         helper.registerAllowedMethod('timeout', [Map])
-        helper.registerAllowedMethod("timeout", [Map, Closure]) { Closure c ->
+        helper.registerAllowedMethod('timeout', [Map, Closure]) { Map args, Closure c ->
             c.delegate = delegate
             helper.callClosure(c)
         }
@@ -197,7 +197,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod('unstash', [Map])
         helper.registerAllowedMethod('usernamePassword', [Map], usernamePasswordInterceptor)
         helper.registerAllowedMethod('waitUntil', [Closure])
-        helper.registerAllowedMethod("warnError", [String, Closure], { Closure c ->
+        helper.registerAllowedMethod("warnError", [String, Closure], { String arg, Closure c ->
             try {
                 c.delegate = delegate
                 helper.callClosure(c)


### PR DESCRIPTION
These closures are called with two arguments: the arguments passed to
the step, and the closure to execute. If there is no placeholder
variable for the arguments, then this will result in the helper
mistakenly attempting to execute the arguments as a closure.