### PR TITLE
Handle default return correctly when returnStatus is used

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -683,7 +683,7 @@ class PipelineTestHelper {
         if (exitValue != 0) {
             throw new Exception('Script returned error code: ' + exitValue)
         }
-        return // no default return value requested
+        return null
     }
 
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -633,6 +633,9 @@ class PipelineTestHelper {
 
         MockScriptOutput output = mockScriptOutputs[script]
         if (!output) {
+            if (returnStatus) {
+                return 0
+            }
             // If no output is given, we return these strings for backwards-compatibility. Ideally at some point in the
             // future, we should make a breaking change and remove this special use-case and either raise an exception
             // here or return an empty string.
@@ -680,6 +683,7 @@ class PipelineTestHelper {
         if (exitValue != 0) {
             throw new Exception('Script returned error code: ' + exitValue)
         }
+        return // no default return value requested
     }
 
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -266,6 +266,18 @@ class PipelineTestHelperTest {
     }
 
     @Test()
+    void runShWithoutMockOutputAndReturnStatus() throws Exception {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def output = helper.runSh(returnStatus: true, script: 'unregistered-mock-output')
+
+        // then:
+        Assertions.assertThat(output).isEqualTo(0)
+    }
+
+    @Test()
     void runShWithoutMockOutputForGitRevParse() throws Exception {
         // given:
         def helper = new PipelineTestHelper()


### PR DESCRIPTION
The original default behavior for the `sh` step was undefined and fell
through the inaccurate handling of the resturnStdout behavior. This will
result in a success returnStatus when requested instead of a string
return.