### PR TITLE
Add support for "not" in "when" directive

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/NotDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/NotDeclaration.groovy
@@ -1,0 +1,9 @@
+package com.lesfurets.jenkins.unit.declarative
+
+class NotDeclaration extends WhenDeclaration {
+
+    boolean execute(Object delegate) {
+        return !super.execute(delegate)
+    }
+}
+

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -9,6 +9,7 @@ import static groovy.lang.Closure.*
 class WhenDeclaration {
 
     AnyOfDeclaration anyOf
+    NotDeclaration not
     Boolean buildingTag = false
     String branch
     String tag
@@ -22,6 +23,10 @@ class WhenDeclaration {
 
     def anyOf(@DelegatesTo(strategy = DELEGATE_ONLY, value = AnyOfDeclaration) Closure closure) {
         this.anyOf = createComponent(AnyOfDeclaration, closure)
+    }
+
+    def not(@DelegatesTo(strategy = DELEGATE_ONLY, value = NotDeclaration) Closure closure) {
+        this.not = createComponent(NotDeclaration, closure)
     }
 
     def environment(String name, Object value) {
@@ -54,9 +59,13 @@ class WhenDeclaration {
         boolean ta = true
         boolean env = true
         boolean any_of = true
+        boolean not_ = true
 
         if (anyOf) {
             any_of = anyOf.execute(delegate)
+        }
+        if (not) {
+            not_ = not.execute(delegate)
         }
         if (expression) {
             exp = executeWith(delegate, expression)
@@ -76,7 +85,7 @@ class WhenDeclaration {
             }
         }
 
-        return exp && br && ta && env && any_of
+        return exp && br && ta && env && any_of && not_
     }
 
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -92,6 +92,14 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void when_not_branch_master() throws Exception {
+        addEnvVar('BRANCH_NAME', 'dev')
+        runScript('not_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Running')
+        assertJobStatusSuccess()
+    }
+
     @Test void when_anyOf_branch_not() throws Exception {
         addEnvVar('BRANCH_NAME', 'master')
         runScript('AnyOf_Jenkinsfile')
@@ -99,6 +107,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertCallStack().contains('Skipping stage Example anyOf branch')
         assertJobStatusSuccess()
     }
+
     @Test void when_anyOf_branch() throws Exception {
         addEnvVar('BRANCH_NAME', 'production')
         runScript('AnyOf_Jenkinsfile')

--- a/src/test/jenkins/jenkinsfiles/not_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/not_Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+    stages {
+        stage('Example not') {
+            when {
+                not {
+                    branch "master"
+                }
+            }
+            steps {
+                echo 'Running'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementing `not` for `when` directive.

As docs says:

```
Execute the stage when the nested condition is false. Must contain one condition. For example: when { not { branch 'master' }}
```

