### PR TITLE
Allow AnyOf directive to work with multiple validations

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AnyOfDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AnyOfDeclaration.groovy
@@ -1,3 +1,43 @@
 package com.lesfurets.jenkins.unit.declarative
 
-class AnyOfDeclaration extends WhenDeclaration {}
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
+
+class AnyOfDeclaration extends WhenDeclaration {
+
+    List<String> branches = []
+    List<Boolean> expressions = []
+
+    def branch(String name) {
+        this.branches.add(name)
+    }
+
+    def expression(Closure closure) {
+        this.expressions.add(closure)
+    }
+
+    def expressions(delegate) {
+        def exp_result;
+        for (def exp in this.expressions) {
+            exp_result = executeWith(delegate, exp)
+            if (exp_result) {
+                return true
+            }
+        }
+        return false
+    }
+
+    boolean execute(Object delegate) {
+        boolean br = false;
+        boolean exp = false;
+
+        if (this.branches.size() > 0) {
+            br = this.branches.contains(delegate.env.BRANCH_NAME)
+        }
+
+        if (this.expressions.size() > 0) {
+            exp = expressions(delegate)
+        }
+
+        return exp || br
+    }
+}

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -108,7 +108,15 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
-    @Test void when_anyOf_branch() throws Exception {
+    @Test void when_anyOf_multiple_branch_release() throws Exception {
+        addEnvVar('BRANCH_NAME', 'release')
+        runScript('AnyOf_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Executing anyOf with branch')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_anyOf_branch_production() throws Exception {
         addEnvVar('BRANCH_NAME', 'production')
         runScript('AnyOf_Jenkinsfile')
         printCallStack()

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -108,7 +108,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
-    @Test void when_anyOf_multiple_branch_release() throws Exception {
+    @Test void when_anyOf_branch_release() throws Exception {
         addEnvVar('BRANCH_NAME', 'release')
         runScript('AnyOf_Jenkinsfile')
         printCallStack()

--- a/src/test/jenkins/jenkinsfiles/AnyOf_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/AnyOf_Jenkinsfile
@@ -12,16 +12,20 @@ pipeline {
                     expression {
                         return env.SHOULD_EXECUTE == 'true'
                     }
+                    expression {
+                        return 1 == 2
+                    }
                 }
             }
             steps {
                 echo 'Executing anyOf with expression'
             }
         }
-        stage('Example anyOf branch') {
+        stage('Example anyOf branches') {
             when {
                 anyOf {
                     branch 'production'
+                    branch 'release'
                 }
             }
             steps {


### PR DESCRIPTION
As noted [here](https://github.com/jenkinsci/JenkinsPipelineUnit/issues/227#issuecomment-689877625)

`AnyOf` implementation does not work with multiple conditions, example:

```
...
        stage('Example anyOf branches') {
            when {
                anyOf {
                    branch 'production'
                    branch 'release'
                }
            }
            steps {
                echo 'Executing anyOf with branch'
            }
        }
...
```

This PR adds supports for multiple conditions in `AnyOf` directive for `branch` and `expression`.