### PR TITLE
Allow kubernetes agent to be constructed with a map/object

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -1,16 +1,12 @@
 package com.lesfurets.jenkins.unit.declarative
 
-import groovy.transform.Memoized
-import groovy.transform.ToString
-
 import com.lesfurets.jenkins.unit.declarative.agent.DockerAgentDeclaration
 import com.lesfurets.jenkins.unit.declarative.agent.KubernetesAgentDeclaration
+import groovy.transform.ToString
 
 import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.createComponent
 import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeWith
-import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
 import static groovy.lang.Closure.DELEGATE_ONLY
-
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
 class AgentDeclaration {
@@ -48,8 +44,12 @@ class AgentDeclaration {
         this.docker = createComponent(DockerAgentDeclaration, closure)
     }
 
+    def kubernetes(Object kubernetesAgent) {
+        this.@kubernetes = kubernetesAgent as KubernetesAgentDeclaration
+    }
+
     def kubernetes(@DelegatesTo(strategy = DELEGATE_ONLY, value = KubernetesAgentDeclaration) Closure closure) {
-        this.kubernetes = createComponent(KubernetesAgentDeclaration, closure)
+        this.@kubernetes = createComponent(KubernetesAgentDeclaration, closure)
     }
 
     def dockerfile(boolean dockerfile) {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -181,6 +181,14 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void should_kubernetes_map_agent() throws Exception {
+        runScript('Kubernetes_Map_Agent_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('namespace: "jenkins"')
+        assertCallStack().contains('image: jenkins/slave')
+        assertJobStatusSuccess()
+    }
+
     @Test void should_credentials() throws Exception {
         addCredential('my-prefined-secret-text', 'something_secret')
         runScript('Credentials_Jenkinsfile')

--- a/src/test/jenkins/jenkinsfiles/Kubernetes_Map_Agent_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Kubernetes_Map_Agent_Jenkinsfile
@@ -1,0 +1,57 @@
+pipeline {
+    agent none
+    stages {
+        stage('Example Build') {
+            agent {
+                kubernetes(
+                  [ 'cloud': 'kubernetes',
+                  'label': 'testLabel',
+                  'yaml':  """metadata:
+                        namespace: "jenkins"
+                      spec:
+                        containers:
+                          - name: jnlp
+                            image: jenkins/slave:4.3-8
+                            resources:
+                              requests:
+                                cpu: "500m"
+                                memory: "4Gi"
+                              limits:
+                                memory: "4Gi"
+                                cpu: 2.0
+                            workingDir: /home/jenkins/agent
+                            env:
+                              - name: CONTAINER_ENV_VAR
+                                value: jnlp
+                              - name: JAVA_OPTS
+                                value: "-Duser.timezone=Europe/Amsterdam"
+                            volumeMounts:
+                              - name: log4j2-jenkins
+                                mountPath: "/usr/local/etc/jenkins/log4j2.xml"
+                                subPath: log4j2.xml
+                        volumes:
+                          - name: log4j2-jenkins
+                            configMap:
+                              name: log4j2-jenkins
+                  """]
+                )
+            }
+            steps {
+                echo 'Hello, Kubernetes'
+                sh 'mvn --version'
+            }
+        }
+        stage('Example Test') {
+            agent { kubernetes {
+                  cloud 'kubernetes'
+                  label 'testLabel'
+                  yamlFile 'KubernetesPod.yaml'
+              }
+            }
+            steps {
+                echo 'Hello, JDK'
+                sh 'java -version'
+            }
+        }
+    }
+}


### PR DESCRIPTION
In our project we use a custom version of:
https://github.com/liejuntao001/jenkins-k8sagent-lib/blob/master/vars/k8sagent.groovy

Which basically returns a Map to construct a kubernetes agent with. This fix should allow constructing the kubernetes agent declaration based on a Map/Object

