### PR TITLE
Register timeout with integer argument

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -211,6 +211,10 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("stage", [String, Closure])
         helper.registerAllowedMethod("step", [Map])
         helper.registerAllowedMethod("string", [Map], stringInterceptor)
+        helper.registerAllowedMethod('timeout', [Integer, Closure], { Map args, Closure c ->
+            c.delegate = delegate
+            helper.callClosure(c)
+        })
         helper.registerAllowedMethod('timeout', [Map])
         helper.registerAllowedMethod('timeout', [Map, Closure], { Map args, Closure c ->
             c.delegate = delegate


### PR DESCRIPTION
When an integer is given, it is assumed to be a value in minutes.