### PR TITLE
Pass param value maps back

### DIFF
--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -524,4 +524,13 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test
+    void should_log_downstream_var() throws Exception {
+        runScript('DownstreamBuild_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('build({job=stop, parameters=[{name=stringVarName, value=stringVarValue}, {name=secretVarName, value=***********}, {name=booleanVarName, value=true}], wait=true}')
+        assertJobStatusSuccess()
+
+    }
+
 }

--- a/src/test/jenkins/jenkinsfiles/DownstreamBuild_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/DownstreamBuild_Jenkinsfile
@@ -1,0 +1,18 @@
+pipeline {
+    agent none
+    stages {
+        stage('Run subbuild') {
+            parallel {
+                stage('Build') {
+                    steps {
+                        build(job: "stop", parameters: [
+                                string(name: 'stringVarName', value: 'stringVarValue'),
+                                password(name: 'secretVarName', value: 'superSecret'),
+                                booleanParam(name: 'booleanVarName', value: 'true')
+                        ], wait: true)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Given the build step:
```groovy
stage("Call` some other build") {
                steps {
                    script {
                        build(job: "start", parameters: [string(name: 'application', value: 'All')], wait: true)
                    }
                }
            }
```

Shows up as:
```bash
build({job=start, parameters=[null], wait=true})
```
I don't see the use for the `paramInterceptor` outside the `ParametersDeclaration`. I would like to see the params a build is called with in the call stack.

UPD: Updated formatting.