### PR TITLE
Implement propertyMissing method

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -11,6 +11,7 @@ class InterceptingGCL extends GroovyClassLoader {
         metaClazz.invokeMethod = helper.getMethodInterceptor()
         metaClazz.static.invokeMethod = helper.getMethodInterceptor()
         metaClazz.methodMissing = helper.getMethodMissingInterceptor()
+        metaClazz.propertyMissing = helper.getPropertyMissingInterceptor()
         metaClazz.getEnv = {return binding.env}
         // find and replace script method closure with any matching allowed method closure
         metaClazz.methods.forEach { scriptMethod ->

--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -12,7 +12,7 @@ class InterceptingGCL extends GroovyClassLoader {
         metaClazz.static.invokeMethod = helper.getMethodInterceptor()
         metaClazz.methodMissing = helper.getMethodMissingInterceptor()
         metaClazz.propertyMissing = helper.getPropertyMissingInterceptor()
-        metaClazz.getEnv = {return binding.env}
+        metaClazz.getEnv = { return binding.env }
         // find and replace script method closure with any matching allowed method closure
         metaClazz.methods.forEach { scriptMethod ->
             def signature = method(scriptMethod.name, scriptMethod.nativeParameterTypes)
@@ -67,10 +67,7 @@ class InterceptingGCL extends GroovyClassLoader {
             return super.loadClass(name)
         }
 
-        // Copy from this.parseClass(GroovyCodeSource, boolean)
-        cls.metaClass.invokeMethod = helper.getMethodInterceptor()
-        cls.metaClass.static.invokeMethod = helper.getMethodInterceptor()
-        cls.metaClass.methodMissing = helper.getMethodMissingInterceptor()
+        interceptClassMethods(cls.metaClass, helper, binding)
 
         return cls;
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -185,9 +185,9 @@ class PipelineTestHelper {
             return callClosure(intercepted.value, args)
         }
         // if not search for the method declaration
-        MetaMethod m = delegate.metaClass.getMetaMethod(name, args)
+        MetaMethod metaMethod = delegate.metaClass.getMetaMethod(name, args)
         // ...and call it. If we cannot find it, delegate call to methodMissing
-        def result = (m ? this.callMethod(m, delegate, args) : delegate.metaClass.invokeMissingMethod(delegate, name, args))
+         def result = (metaMethod ? this.callMethod(metaMethod, delegate, args) : delegate.metaClass.invokeMissingMethod(delegate, name, args))
         return result
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -234,6 +234,20 @@ class PipelineTestHelper {
         return methodMissingInterceptor
     }
 
+    def propertyMissingInterceptor = { String propertyName ->
+        if (binding.hasVariable("params") && (binding.getVariable("params") as Map).containsKey(propertyName)) {
+            return (binding.getVariable("params") as Map).get(propertyName)
+        }
+        if (binding.getVariable("env") && (binding.getVariable("env") as Map).containsKey(propertyName)) {
+            return (binding.getVariable("env") as Map).get(propertyName)
+        }
+        throw new MissingPropertyException(propertyName)
+    }
+
+    def getPropertyMissingInterceptor() {
+        return propertyMissingInterceptor
+    }
+
     def callIfClosure(Object closure, Object currentResult) {
         if (closure instanceof Closure) {
             currentResult = callClosure(closure)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -4,10 +4,12 @@ import com.lesfurets.jenkins.unit.declarative.agent.DockerAgentDeclaration
 import com.lesfurets.jenkins.unit.declarative.agent.KubernetesAgentDeclaration
 import groovy.transform.ToString
 
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
 import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class AgentDeclaration extends GenericPipelineDeclaration {
+class AgentDeclaration {
 
     String label
     DockerAgentDeclaration docker
@@ -16,7 +18,6 @@ class AgentDeclaration extends GenericPipelineDeclaration {
     String dockerfileDir
     Boolean reuseNode = null
     String customWorkspace
-    def binding = null
 
     def label(String label) {
         this.label = label
@@ -35,7 +36,7 @@ class AgentDeclaration extends GenericPipelineDeclaration {
     }
 
     def docker(String image) {
-        this.docker = new DockerAgentDeclaration().with { it.image = image; it }
+        this.docker({ -> this.image = image })
     }
 
     def docker(@DelegatesTo(strategy = DELEGATE_FIRST, value = DockerAgentDeclaration) Closure closure) {
@@ -60,18 +61,6 @@ class AgentDeclaration extends GenericPipelineDeclaration {
 
     def dir(String dir) {
         this.dockerfileDir = dir
-    }
-
-    def getCurrentBuild() {
-        return binding?.currentBuild
-    }
-
-    def getEnv() {
-        return binding?.env
-    }
-
-    def getParams() {
-        return binding?.params
     }
 
     def execute(Object delegate) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipeline.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipeline.groovy
@@ -8,7 +8,7 @@ class DeclarativePipeline extends GenericPipelineDeclaration {
     List<Closure> options = []
 
     Closure triggers
-    ParametersDeclaration params = null
+    ParametersDeclaration parameters = null
 
     DeclarativePipeline() {
         properties.put('any', 'any')
@@ -24,10 +24,6 @@ class DeclarativePipeline extends GenericPipelineDeclaration {
         }
     }
 
-    def propertyMissing(String name, arg) {
-
-    }
-
     def options(@DelegatesTo(DeclarativePipeline) Closure closure) {
         options.add(closure)
     }
@@ -37,20 +33,20 @@ class DeclarativePipeline extends GenericPipelineDeclaration {
     }
 
     def parameters(Object o) {
-        this.params = new ParametersDeclaration().with { it.label = o; it }
+        this.parameters = new ParametersDeclaration().with { it.label = o; it }
     }
 
     def parameters(@DelegatesTo(strategy=DELEGATE_FIRST, value=ParametersDeclaration) Closure closure) {
-        this.params = createComponent(ParametersDeclaration, closure)
+        this.parameters = createComponent(ParametersDeclaration, closure)
     }
 
     def execute(Object delegate) {
         super.execute(delegate)
         this.options.forEach {
-            executeOn(delegate, it)
+            executeWith(delegate, it)
         }
         this.agent?.execute(delegate)
-        executeOn(delegate, this.triggers)
+        executeWith(delegate, this.triggers)
         this.stages.entrySet().forEach { e ->
             e.value.execute(delegate)
         }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/DeclarativePipelineTest.groovy
@@ -8,15 +8,18 @@ import static com.lesfurets.jenkins.unit.MethodSignature.method
 abstract class DeclarativePipelineTest extends BasePipelineTest {
 
     def pipelineInterceptor = { Closure closure ->
-        GenericPipelineDeclaration.binding = binding
-        GenericPipelineDeclaration.createComponent(DeclarativePipeline, closure).execute(delegate)
+        def declarativePipeline = new DeclarativePipeline()
+        def rehydratedPipelineCl = closure.rehydrate(declarativePipeline, closure.owner, closure)
+        rehydratedPipelineCl.resolveStrategy
+        rehydratedPipelineCl.call();
+        declarativePipeline.execute(closure.owner)
     }
 
     def paramInterceptor = { Map desc ->
         addParam(desc.name, desc.defaultValue, false)
     }
 
-    def stringInterceptor = { Map desc->
+    def stringInterceptor = { Map desc ->
         if (desc) {
             // we are in context of parameters { string(...)}
             if (desc.name) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/NotDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/NotDeclaration.groovy
@@ -2,8 +2,8 @@ package com.lesfurets.jenkins.unit.declarative
 
 class NotDeclaration extends WhenDeclaration {
 
-    Boolean execute(Object delegate) {
-        return !super.execute(delegate)
+    Boolean execute(Script script) {
+        return !super.execute(script)
     }
 }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
@@ -1,10 +1,11 @@
 package com.lesfurets.jenkins.unit.declarative
 
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
 import static groovy.lang.Closure.DELEGATE_FIRST
-//import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeOn
 
-class ParallelDeclaration extends GenericPipelineDeclaration {
+class ParallelDeclaration {
 
+    Map<String, StageDeclaration> stages = [:]
     boolean failFast
 
     ParallelDeclaration(boolean failFast) {
@@ -21,7 +22,6 @@ class ParallelDeclaration extends GenericPipelineDeclaration {
     }
 
     def execute(Object delegate) {
-        super.execute(delegate)
         this.stages.entrySet().forEach { e ->
             e.value.execute(delegate)
         }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParallelDeclaration.groovy
@@ -1,8 +1,5 @@
 package com.lesfurets.jenkins.unit.declarative
 
-import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
-import static groovy.lang.Closure.DELEGATE_FIRST
-
 class ParallelDeclaration {
 
     Map<String, StageDeclaration> stages = [:]
@@ -16,14 +13,15 @@ class ParallelDeclaration {
         this.failFast = false
     }
 
-    def stage(String name,
-              @DelegatesTo(strategy = DELEGATE_FIRST, value = StageDeclaration) Closure closure) {
-        this.stages.put(name, createComponent(StageDeclaration, closure).with{it.name = name;it} )
+    def stage(String name, Closure closure) {
+        def stageDeclaration = new StageDeclaration(name);
+        GenericPipelineDeclaration.executeWith(stageDeclaration, closure);
+        this.stages.put(name, stageDeclaration)
     }
 
-    def execute(Object delegate) {
+    def execute(Script script) {
         this.stages.entrySet().forEach { e ->
-            e.value.execute(delegate)
+            e.value.execute(script)
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParametersDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/ParametersDeclaration.groovy
@@ -1,12 +1,15 @@
 package com.lesfurets.jenkins.unit.declarative
 
 
-class ParametersDeclaration extends GenericPipelineDeclaration {
+class ParametersDeclaration {
+    Binding binding
 
-    void setParams(String key, Object val) {
-        Map params = this.params
-        if (params != null && (!params.containsKey(key))) {
-            params[key] = val
+    void setParams(String key, Object defaultValue) {
+        if (!binding.hasVariable("params")) {
+            binding.setVariable("params", [:])
+        }
+        if (!binding.params.containsKey(key)) {
+            binding.params[key] = defaultValue
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -1,6 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative
 
-import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeOn
+import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeWith
 
 class PostDeclaration {
 
@@ -59,48 +59,48 @@ class PostDeclaration {
         def currentBuild = delegate.currentBuild.result
         def previousBuild = delegate.currentBuild?.previousBuild?.result
         if (this.always) {
-            executeOn(delegate, this.always)
+            executeWith(delegate, this.always)
         }
 
         switch (currentBuild) {
             case 'SUCCESS':
-                executeOn(delegate, this.success)
+                executeWith(delegate, this.success)
                 break
             case 'FAILURE':
-                executeOn(delegate, this.failure)
+                executeWith(delegate, this.failure)
                 break
             case 'ABORTED':
-                executeOn(delegate, this.aborted)
+                executeWith(delegate, this.aborted)
                 break
             case 'UNSTABLE':
-                executeOn(delegate, this.unstable)
+                executeWith(delegate, this.unstable)
                 break
         }
 
         if(currentBuild != previousBuild && this.changed)
         {
-            executeOn(delegate, this.changed)
+            executeWith(delegate, this.changed)
         }
         if(currentBuild != 'SUCCESS' && this.unsuccessful)
         {
-            executeOn(delegate, this.unsuccessful)
+            executeWith(delegate, this.unsuccessful)
         }
         if(this.fixed){
             if(currentBuild == 'SUCCESS' && (previousBuild == 'FAILURE' || previousBuild == 'UNSTABLE'))
             {
-                executeOn(delegate, this.fixed)
+                executeWith(delegate, this.fixed)
             }
         }
         if(this.regression)
         {
             if((currentBuild == 'FAILURE' || currentBuild == 'UNSTABLE') && previousBuild == 'SUCCESS'){
-                executeOn(delegate, this.regression)
+                executeWith(delegate, this.regression)
             }
         }
 
         // Cleanup is always performed last
         if(this.cleanup){
-            executeOn(delegate, this.cleanup)
+            executeWith(delegate, this.cleanup)
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/PostDeclaration.groovy
@@ -1,6 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative
 
-import static com.lesfurets.jenkins.unit.declarative.DeclarativePipeline.executeWith
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
 
 class PostDeclaration {
 
@@ -55,52 +55,52 @@ class PostDeclaration {
         this.regression = closure
     }
 
-    def execute(Object delegate) {
-        def currentBuild = delegate.currentBuild.result
-        def previousBuild = delegate.currentBuild?.previousBuild?.result
+    def execute(Script script) {
+        def currentBuild = script.currentBuild.result
+        def previousBuild = script.currentBuild?.previousBuild?.result
         if (this.always) {
-            executeWith(delegate, this.always)
+            executeWith(script, this.always)
         }
 
         switch (currentBuild) {
             case 'SUCCESS':
-                executeWith(delegate, this.success)
+                executeWith(script, this.success)
                 break
             case 'FAILURE':
-                executeWith(delegate, this.failure)
+                executeWith(script, this.failure)
                 break
             case 'ABORTED':
-                executeWith(delegate, this.aborted)
+                executeWith(script,this.aborted)
                 break
             case 'UNSTABLE':
-                executeWith(delegate, this.unstable)
+                executeWith(script,this.unstable)
                 break
         }
 
         if(currentBuild != previousBuild && this.changed)
         {
-            executeWith(delegate, this.changed)
+            executeWith(script,this.changed)
         }
         if(currentBuild != 'SUCCESS' && this.unsuccessful)
         {
-            executeWith(delegate, this.unsuccessful)
+            executeWith(script, this.unsuccessful)
         }
         if(this.fixed){
             if(currentBuild == 'SUCCESS' && (previousBuild == 'FAILURE' || previousBuild == 'UNSTABLE'))
             {
-                executeWith(delegate, this.fixed)
+                executeWith(script, this.fixed)
             }
         }
         if(this.regression)
         {
             if((currentBuild == 'FAILURE' || currentBuild == 'UNSTABLE') && previousBuild == 'SUCCESS'){
-                executeWith(delegate, this.regression)
+                executeWith(script, this.regression)
             }
         }
 
         // Cleanup is always performed last
         if(this.cleanup){
-            executeWith(delegate, this.cleanup)
+            executeWith(script, this.cleanup)
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -4,8 +4,7 @@ import org.springframework.util.AntPathMatcher
 
 import java.util.regex.Pattern
 
-import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
-import static groovy.lang.Closure.DELEGATE_FIRST
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
 
 class WhenDeclaration {
 
@@ -24,36 +23,35 @@ class WhenDeclaration {
         return Pattern.compile('^' + Pattern.quote(glob).replace('*', '\\E.*\\Q').replace('?', '\\E.\\Q') + '$')
     }
 
-    def allOf(@DelegatesTo(strategy = DELEGATE_FIRST, value = AllOfDeclaration) Closure closure) {
-        this.allOf = createComponent(AllOfDeclaration, closure)
+    def allOf(Closure closure) {
+        this.allOf = new AllOfDeclaration()
+        executeWith(this.allOf, closure, Closure.DELEGATE_FIRST)
     }
 
-    def anyOf(@DelegatesTo(strategy = DELEGATE_FIRST, value = AnyOfDeclaration) Closure closure) {
-        this.anyOfCondition = createComponent(AnyOfDeclaration, closure)
+    def anyOf(Closure closure) {
+        this.anyOf = new AnyOfDeclaration();
+        executeWith(this.anyOf, closure, Closure.DELEGATE_FIRST);
     }
 
-    def not(@DelegatesTo(strategy = DELEGATE_FIRST, value = NotDeclaration) Closure closure) {
-        this.notCondition = createComponent(NotDeclaration, closure)
+    def not(Closure closure) {
+        this.not = new NotDeclaration();
+        executeWith(this.not, closure, Closure.DELEGATE_FIRST)
     }
 
     def branch (String name) {
-        this.branchCondition = name
-    }
-
-    def environment(Map condition){
-        this.environmentCondition = condition
+        this.branch = name
     }
 
     def tag (String name) {
-        this.tagCondition = getPatternFromGlob(name)
+        this.tag = getPatternFromGlob(name)
     }
 
     def buildingTag () {
-        this.buildingTagCondition = true
+        this.buildingTag = true
     }
 
     def expression(Closure closure) {
-        this.expressionCondition = closure
+        this.expression = closure
     }
 
     def environment(Map args) {
@@ -61,7 +59,7 @@ class WhenDeclaration {
         this.envValue = args.value as String
     }
 
-    Boolean execute(Object delegate) {
+    Boolean execute(Script script) {
         boolean expressionCheck = true
         boolean branchCheck = true
         boolean tagCheck = true
@@ -71,29 +69,29 @@ class WhenDeclaration {
         boolean notCheck = true
 
         if (allOf) {
-            allOfCheck = allOf.execute(delegate)
+            allOfCheck = allOf.execute(script)
         }
         if (anyOf) {
-            anyOfCheck = anyOf.execute(delegate)
+            anyOfCheck = anyOf.execute(script)
         }
-        if (notCondition) {
-            notCheck = notCondition.execute(delegate)
+        if (not) {
+            notCheck = not.execute(script)
         }
-        if (expressionCondition) {
-            expressionCheck = executeWith(delegate, expressionCondition)
+        if (expression) {
+            expressionCheck = executeWith(script, expression)
         }
         if (branch) {
             AntPathMatcher antPathMatcher = new AntPathMatcher()
-            branchCheck = antPathMatcher.match(branch, delegate.env.BRANCH_NAME)
+            branchCheck = antPathMatcher.match(branch, script.env.BRANCH_NAME)
         }
         if (buildingTag) {
-            tagCheck = delegate?.env?.containsKey("TAG_NAME")
+            tagCheck = script?.env?.containsKey("TAG_NAME")
         }
-        if (tagCondition) {
-            tagCheck = delegate.env.TAG_NAME =~ tagCondition
+        if (tag) {
+            tagCheck = script.env.TAG_NAME =~ tag
         }
         if (envName != null) {
-            def val = delegate?.env[envName]
+            def val = script?.env[envName]
             envCheck = (val == envValue)
         }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerAgentDeclaration.groovy
@@ -1,13 +1,12 @@
 package com.lesfurets.jenkins.unit.declarative.agent
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
 import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class DockerAgentDeclaration extends GenericPipelineDeclaration {
+class DockerAgentDeclaration {
 
     String label
     String args = ""

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/KubernetesAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/KubernetesAgentDeclaration.groovy
@@ -1,14 +1,13 @@
 package com.lesfurets.jenkins.unit.declarative.agent
 
-
+import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import com.lesfurets.jenkins.unit.declarative.kubernetes.ContainerTemplateDeclaration
 import com.lesfurets.jenkins.unit.declarative.kubernetes.WorkspaceVolumeDeclaration
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
-import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
 import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
-import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
 class KubernetesAgentDeclaration {
@@ -17,14 +16,14 @@ class KubernetesAgentDeclaration {
     String customWorkspace;
     String cloud;
     String inheritFrom;
-    int idleMinutes;
-    int instanceCap;
+    Integer idleMinutes;
+    Integer instanceCap;
     String serviceAccount;
     String nodeSelector;
     String namespace;
     String workingDir;
-    int activeDeadlineSeconds;
-    int slaveConnectTimeout;
+    Integer activeDeadlineSeconds;
+    Integer slaveConnectTimeout;
     String podRetention;
     ContainerTemplateDeclaration containerTemplate;
     List<ContainerTemplateDeclaration> containerTemplates;
@@ -87,13 +86,16 @@ class KubernetesAgentDeclaration {
         this.podRetention = podRetention
     }
 
-    def containerTemplate(@DelegatesTo(strategy = DELEGATE_FIRST, value = ContainerTemplateDeclaration) Closure closure) {
-        this.containerTemplate = createComponent(ContainerTemplateDeclaration, closure)
+    def containerTemplate(Closure closure) {
+        this.containerTemplate = new ContainerTemplateDeclaration();
+        executeWith(this.containerTemplate, closure)
     }
 
-    def containerTemplates(@DelegatesTo(strategy = DELEGATE_FIRST, value = ContainerTemplateDeclaration) List<Closure> closures) {
-        this.containerTemplates = closures.each { ct ->
-            return createComponent(ContainerTemplateDeclaration, ct)
+    def containerTemplates(List<Closure> closures) {
+        this.containerTemplates = closures.collect { ctClosure ->
+            def containerTemplateDeclaration = new ContainerTemplateDeclaration();
+            executeWith(containerTemplateDeclaration, ctClosure)
+            return containerTemplateDeclaration;
         } as List<ContainerTemplateDeclaration>
     }
 
@@ -113,8 +115,9 @@ class KubernetesAgentDeclaration {
         this.yamlMergeStrategy = yamlMergeStrategy
     }
 
-    def workspaceVolume(@DelegatesTo(strategy = DELEGATE_FIRST, value = WorkspaceVolumeDeclaration) Closure closure) {
-        this.workspaceVolume = createComponent(WorkspaceVolumeDeclaration, closure)
+    def workspaceVolume(Closure closure) {
+        this.workspaceVolume = new WorkspaceVolumeDeclaration();
+        executeWith(this.workspaceVolume, closure)
     }
 
     def supplementalGroups(final String supplementalGroups) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/KubernetesAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/KubernetesAgentDeclaration.groovy
@@ -1,6 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative.agent
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
+
 import com.lesfurets.jenkins.unit.declarative.kubernetes.ContainerTemplateDeclaration
 import com.lesfurets.jenkins.unit.declarative.kubernetes.WorkspaceVolumeDeclaration
 import groovy.transform.Memoized
@@ -11,7 +11,7 @@ import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullPro
 import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class KubernetesAgentDeclaration extends GenericPipelineDeclaration {
+class KubernetesAgentDeclaration {
 
     String label;
     String customWorkspace;

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerLivenessProbeDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerLivenessProbeDeclaration.groovy
@@ -1,8 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
-
-class ContainerLivenessProbeDeclaration extends GenericPipelineDeclaration {
+class ContainerLivenessProbeDeclaration {
 
     String execArgs
     int timeoutSeconds

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerTemplateDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerTemplateDeclaration.groovy
@@ -1,12 +1,11 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-
+import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
-import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.createComponent
+import static com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration.executeWith
 import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
-import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
 class ContainerTemplateDeclaration {
@@ -90,14 +89,17 @@ class ContainerTemplateDeclaration {
         this.shell = shell
     }
 
-    def ports(@DelegatesTo(strategy = DELEGATE_FIRST, value = PortMappingDeclaration) List<Closure> closures) {
+    def ports(List<Closure> closures) {
         this.ports = closures.each { ct ->
-            return createComponent(PortMappingDeclaration, ct)
+            def portMappingDeclaration = new PortMappingDeclaration()
+            executeWith(portMappingDeclaration, closure)
+            return portMappingDeclaration
         } as List<PortMappingDeclaration>
     }
 
-    def livenessProbe(@DelegatesTo(strategy = DELEGATE_FIRST, value = ContainerLivenessProbeDeclaration) Closure closure) {
-        this.livenessProbe = createComponent(ContainerLivenessProbeDeclaration, ct)
+    def livenessProbe(Closure closure) {
+        this.livenessProbe = new ContainerLivenessProbeDeclaration();
+        executeWith(this.livenessProbe, closure)
     }
 
     @Memoized

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerTemplateDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/ContainerTemplateDeclaration.groovy
@@ -1,6 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
+
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
@@ -9,7 +9,7 @@ import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullPro
 import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class ContainerTemplateDeclaration extends GenericPipelineDeclaration {
+class ContainerTemplateDeclaration {
 
     String name;
     String image;

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/PodTemplateDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/PodTemplateDeclaration.groovy
@@ -1,7 +1,4 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
-
-
-class PodTemplateDeclaration extends GenericPipelineDeclaration {
+class PodTemplateDeclaration {
 }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/PortMappingDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/PortMappingDeclaration.groovy
@@ -1,13 +1,13 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
+
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
 import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class PortMappingDeclaration extends GenericPipelineDeclaration {
+class PortMappingDeclaration {
     String name
     int containerPort
     int hostPort

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/TemplateEnvVarDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/TemplateEnvVarDeclaration.groovy
@@ -1,8 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
-
-class TemplateEnvVarDeclaration extends GenericPipelineDeclaration {
+class TemplateEnvVarDeclaration {
 
     KeyValueVar containerEnvVar;
     KeyValueVar envVar;

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/WorkspaceVolumeDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/WorkspaceVolumeDeclaration.groovy
@@ -1,6 +1,6 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
+
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
@@ -8,7 +8,7 @@ import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullPro
 import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class WorkspaceVolumeDeclaration extends GenericPipelineDeclaration {
+class WorkspaceVolumeDeclaration {
 
     DynamicWorkspaceVolume dynamicPVC
     EmptyDirWorkspaceVolume emptyDirWorkspaceVolume

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/WorkspaceVolumeDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/kubernetes/WorkspaceVolumeDeclaration.groovy
@@ -1,11 +1,10 @@
 package com.lesfurets.jenkins.unit.declarative.kubernetes
 
-
+import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import groovy.transform.Memoized
 import groovy.transform.ToString
 
 import static com.lesfurets.jenkins.unit.declarative.ObjectUtils.printNonNullProperties
-import static groovy.lang.Closure.DELEGATE_FIRST
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
 class WorkspaceVolumeDeclaration {
@@ -16,24 +15,31 @@ class WorkspaceVolumeDeclaration {
     NfsWorkspaceVolume nfsWorkspaceVolume
     PersistentVolumeClaimWorkspaceVolume persistentVolumeClaimWorkspaceVolume
 
-    void dynamicPVC(@DelegatesTo(strategy = DELEGATE_FIRST, value = DynamicWorkspaceVolume) Closure closure) {
-        this.dynamicPVC = createComponent(DynamicWorkspaceVolume, closure)
+    void dynamicPVC(Closure closure) {
+        this.dynamicPVC = new DynamicWorkspaceVolume();
+        GenericPipelineDeclaration.executeWith(this.dynamicPVC, closure);
     }
 
-    void emptyDirWorkspaceVolume(@DelegatesTo(strategy = DELEGATE_FIRST, value = EmptyDirWorkspaceVolume) Closure closure) {
-        this.emptyDirWorkspaceVolume = createComponent(EmptyDirWorkspaceVolume, closure)
+    void emptyDirWorkspaceVolume(Closure closure) {
+        this.emptyDirWorkspaceVolume = new EmptyDirWorkspaceVolume();
+        closure.delegate= this.emptyDirWorkspaceVolume;
+        closure.call();
     }
 
-    void hostPathWorkspaceVolume(@DelegatesTo(strategy = DELEGATE_FIRST, value = HostPathWorkspaceVolume) Closure closure) {
-        this.hostPathWorkspaceVolume = createComponent(HostPathWorkspaceVolume, closure)
+    void hostPathWorkspaceVolume(Closure closure) {
+        this.hostPathWorkspaceVolume = new HostPathWorkspaceVolume();
+        GenericPipelineDeclaration.executeWith(this.hostPathWorkspaceVolume, closure);
+
     }
 
-    void nfsWorkspaceVolume(@DelegatesTo(strategy = DELEGATE_FIRST, value = NfsWorkspaceVolume) Closure closure) {
-        nfsWorkspaceVolume = createComponent(NfsWorkspaceVolume, closure)
+    void nfsWorkspaceVolume(Closure closure) {
+        nfsWorkspaceVolume = new NfsWorkspaceVolume();
+        GenericPipelineDeclaration.executeWith(this.nfsWorkspaceVolume, closure);
     }
 
-    void persistentVolumeClaimWorkspaceVolume(@DelegatesTo(strategy = DELEGATE_FIRST, value = PersistentVolumeClaimWorkspaceVolume) Closure closure) {
-        persistentVolumeClaimWorkspaceVolume = createComponent(PersistentVolumeClaimWorkspaceVolume, closure)
+    void persistentVolumeClaimWorkspaceVolume(Closure closure) {
+        persistentVolumeClaimWorkspaceVolume = new PersistentVolumeClaimWorkspaceVolume();
+        GenericPipelineDeclaration.executeWith(this.persistentVolumeClaimWorkspaceVolume, closure);
     }
 
     @Memoized

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -532,4 +532,11 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void jenkinsfile_thisObject() throws Exception {
+        def script = runScript('Declarative_thisObject_JenkinsFile')
+        printCallStack()
+        assertJobStatusSuccess()
+        assertCallStack().doesNotContain("This is a script?: false")
+        assertCallStack().contains("This is a script?: true")
+    }
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -450,8 +450,10 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
     }
 
     @Test void should_environment() throws Exception {
+        addEnvVar("labelVar","varWorks")
         runScript('Environment_Jenkinsfile')
         printCallStack()
+        assertCallStack().contains('echo(LEVAR1 LE NEW VALUE)')
         assertCallStack().contains('echo(LEVAR1 LE NEW VALUE)')
         assertCallStack().contains('echo(LEVAR2 A COPY OF LE NEW VALUE in build#1)')
         assertJobStatusSuccess()
@@ -493,8 +495,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
     }
 
     @Test void agent_with_mock_param_label() throws Exception {
-        def params = binding.getVariable('params')
-        params['AGENT'] = 'mockSlave'
+        addParam('AGENT', 'mockSlave')
         runScript('AgentParam_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('mockSlave')

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -450,13 +450,20 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
     }
 
     @Test void should_environment() throws Exception {
-        addEnvVar("labelVar","varWorks")
         runScript('Environment_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('echo(LEVAR1 LE NEW VALUE)')
-        assertCallStack().contains('echo(LEVAR1 LE NEW VALUE)')
+        assertCallStack().contains('echo(LEVAR1 LE NEW VALUE without pefixing env)')
         assertCallStack().contains('echo(LEVAR2 A COPY OF LE NEW VALUE in build#1)')
         assertJobStatusSuccess()
+    }
+
+    @Test void should_be_able_to_access_upper_score_var() throws Exception {
+        String envVarValue = "envVarValue"
+        addEnvVar("envVar", envVarValue)
+        runScript('Scoping_Jenkinsfile')
+        assertCallStack().contains("echo(Upperscoped string : UpperScope string with envVar: $envVarValue)")
+        printCallStack()
     }
 
     @Test void not_running_stage_after_failure() throws Exception {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativeWithCredentials.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativeWithCredentials.groovy
@@ -6,7 +6,7 @@ import org.junit.Test
 
 import static org.junit.Assert.assertTrue
 
-class TestDeclaraticeWithCredentials extends DeclarativePipelineTest {
+class TestDeclarativeWithCredentials extends DeclarativePipelineTest {
 
     @Override
     @Before

--- a/src/test/jenkins/jenkinsfiles/Declarative_thisObject_JenkinsFile
+++ b/src/test/jenkins/jenkinsfiles/Declarative_thisObject_JenkinsFile
@@ -1,0 +1,50 @@
+pipeline {
+
+    agent any
+
+    environment {
+        CC = testThis(this, 'gcc')
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: testThis(this, '10')))
+    }
+
+    triggers {
+        pollSCM(testThis(this, '*/5 * * * *'))
+    }
+
+    stages {
+        stage('Checkout') {
+            when {
+                environment name: 'CC', value: testThis(this, 'clang')
+            }
+            steps {
+                echo testThis(this, "Steps")
+            }
+        }
+
+        stage('build') {
+            agent { docker testThis(this, 'maven:3-alpine') }
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
+            steps {
+                withEnv(["GRADLE_HOME=${tool name: 'GRADLE_3', type: 'hudson.plugins.gradle.GradleInstallation'}"]) {
+                    echo testThis(this, "In env")
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            echo testThis(this, 'pipeline unit tests completed')
+        }
+
+    }
+}
+
+String testThis(Script scriptRef, String text){
+    return "$text: This is a script?: ${scriptRef instanceof Script}"
+}

--- a/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                 LEVAR2 = "A COPY OF ${env.LEVAR1} in build#${currentBuild.number}"
             }
             steps {
-                echo "LEVAR1 ${LEVAR1}"
+                echo "LEVAR1 ${env.LEVAR1}"
                 echo "LEVAR1 ${LEVAR1} without pefixing env"
                 echo "LEVAR2 ${env.LEVAR2}"
             }

--- a/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
@@ -1,18 +1,24 @@
-pipeline {
-    agent any
-    environment {
-        LEVAR1 = "LE VALUE 1"
-    }
-    stages {
-        stage('Example') {
-            environment {
-                LEVAR1 = "LE NEW VALUE"
-                LEVAR2 = "A COPY OF ${env.LEVAR1} in build#${currentBuild.number}"
-            }
-            steps {
-                echo "LEVAR1 ${env.LEVAR1}"
-                echo "LEVAR2 ${env.LEVAR2}"
+def call() {
+    String label = "SomePrefix-${labelVar}"
+
+    pipeline {
+        agent label
+        environment {
+            LEVAR1 = "LE VALUE 1"
+        }
+        stages {
+            stage('Example') {
+                environment {
+                    LEVAR1 = "LE NEW VALUE"
+                    LEVAR2 = "A COPY OF ${env.LEVAR1} in build#${currentBuild.number}"
+                }
+                steps {
+                    echo "LEVAR1 ${env.LEVAR1}"
+                    echo "LEVAR2 ${env.LEVAR2}"
+                }
             }
         }
     }
 }
+
+call()

--- a/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Environment_Jenkinsfile
@@ -1,24 +1,19 @@
-def call() {
-    String label = "SomePrefix-${labelVar}"
-
-    pipeline {
-        agent label
-        environment {
-            LEVAR1 = "LE VALUE 1"
-        }
-        stages {
-            stage('Example') {
-                environment {
-                    LEVAR1 = "LE NEW VALUE"
-                    LEVAR2 = "A COPY OF ${env.LEVAR1} in build#${currentBuild.number}"
-                }
-                steps {
-                    echo "LEVAR1 ${env.LEVAR1}"
-                    echo "LEVAR2 ${env.LEVAR2}"
-                }
+pipeline {
+    agent any
+    environment {
+        LEVAR1 = "LE VALUE 1"
+    }
+    stages {
+        stage('Example') {
+            environment {
+                LEVAR1 = "LE NEW VALUE"
+                LEVAR2 = "A COPY OF ${env.LEVAR1} in build#${currentBuild.number}"
+            }
+            steps {
+                echo "LEVAR1 ${LEVAR1}"
+                echo "LEVAR1 ${LEVAR1} without pefixing env"
+                echo "LEVAR2 ${env.LEVAR2}"
             }
         }
     }
 }
-
-call()

--- a/src/test/jenkins/jenkinsfiles/Scoping_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Scoping_Jenkinsfile
@@ -1,0 +1,16 @@
+def call() {
+    String upperscopeSTring = "UpperScope string with envVar: ${envVar}"
+
+    pipeline {
+        agent upperscopeSTring
+        stages {
+            stage('Echo stage') {
+                steps {
+                    echo "Upperscoped string : $upperscopeSTring"
+                }
+            }
+        }
+    }
+}
+
+call()


### PR DESCRIPTION
Undo extending all Declarations from GenericPipelineDeclaration (this adds unwanted properties)
Remove GenericPipelineDeclaration implementation of getProperty.
Instead implement propertyMissing method to fallback to env and params.
Append test to use env var before pipeline closure
Remove duplicate method executeOn (use executeWith instead)
Remove name conflicts between JenkinsFile closures and Declaration fields

Our JenkinsFile had this:

```
def call() {
    String someValue = SomeHelper.someMap.get(ENV_VAR);

    pipeline {
    }
}
```

It seems the previous fix to handle looking into env. and params. does not work outside the pipeline closure. Therefore i looked for another way to fix this. 
During this i noticed the effect extending GenericPipelineDeclaration has on the function printNonNullProperties of ObjectUtils.
So i undid the extending of PipelineDeclaration for declarations that should not be able to handle all those functions(agent, steps etc).
