### PR TITLE
Add fileExists mock

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -157,7 +157,7 @@ abstract class BasePipelineTest {
             println(message)
         })
         helper.registerAllowedMethod("error", [String], { updateBuildStatus('FAILURE') })
-        helper.registerAllowedMethod('fileExists', [String], {true}
+        helper.registerAllowedMethod('fileExists', [String], {true})
         helper.registerAllowedMethod("gatlingArchive")
         helper.registerAllowedMethod("gitlabBuilds", [Map, Closure])
         helper.registerAllowedMethod("gitlabCommitStatus", [String, Closure], { String name, Closure c ->

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -157,6 +157,7 @@ abstract class BasePipelineTest {
             println(message)
         })
         helper.registerAllowedMethod("error", [String], { updateBuildStatus('FAILURE') })
+        helper.registerAllowedMethod('fileExists', [String], {true}
         helper.registerAllowedMethod("gatlingArchive")
         helper.registerAllowedMethod("gitlabBuilds", [Map, Closure])
         helper.registerAllowedMethod("gitlabCommitStatus", [String, Closure], { String name, Closure c ->


### PR DESCRIPTION
This commit adds the fileExist mock that returns "true".  Adding it here so people don't have to mock such a simple step when using the JenkinsPipelineUnit framework.