### PR TITLE
Add fileExists mock with helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,17 +185,17 @@ You can take a look at the `BasePipelineTest` class to have the short list of al
 Some tricky methods such as `load` and `parallel` are implemented directly in the helper.
 If you want to override those, make sure that you extend the `PipelineTestHelper` class.
 
-### Mocking readFile
+### Mocking readFile and fileExists
 
-The `readFile` step can be mocked to return a specific string for a given file name. This can be useful for testing
-pipelines which must read data from a file which is required for subsequent steps. An example of such a testing scenario
-follows:
+The `readFile` and `fileExists` steps can be mocked to return a specific result for a given file name. This can be
+useful for testing pipelines for which file operations can influence subsequent steps. An example of such a testing
+scenario follows:
 
 ```groovy
 // Jenkinsfile
 node {
     stage('Process output') {
-        if (readFile('output') == 'FAILED!!!') {
+        if (fileExists('output') && readFile('output') == 'FAILED!!!') {
             currentBuild.result = 'FAILURE'
             error 'Build failed'
         }
@@ -206,6 +206,7 @@ node {
 ```groovy
 @Test
 void exampleReadFileTest() {
+    helper.addFileExistsMock('fileExists', true)
     helper.addReadFileMock('output', 'FAILED!!!')
     runScript("Jenkinsfile")
     assertJobStatusFailure()

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -171,7 +171,7 @@ abstract class BasePipelineTest {
             helper.getLibLoader().loadImplicitLibraries()
             helper.getLibLoader().loadLibrary(expression)
             helper.setGlobalVars(binding)
-            return new LibClassLoader(helper,null)
+            return new LibClassLoader(helper, null)
         })
         helper.registerAllowedMethod("logRotator", [Map])
         helper.registerAllowedMethod('mail', [Map])
@@ -182,8 +182,8 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod("properties", [List])
         helper.registerAllowedMethod("pwd", [], { 'workspaceDirMocked' })
         helper.registerAllowedMethod("pwd", [Map], { 'tempDirMocked' })
-        helper.registerAllowedMethod('readFile', [Map], { args -> helper.readFile(args )})
-        helper.registerAllowedMethod('readFile', [String], { args -> helper.readFile(args )})
+        helper.registerAllowedMethod('readFile', [Map], { args -> helper.readFile(args) })
+        helper.registerAllowedMethod('readFile', [String], { args -> helper.readFile(args) })
         helper.registerAllowedMethod("retry", [Integer, Closure], { Integer count, Closure c ->
             def attempts = 0
             while (attempts <= count) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -132,7 +132,6 @@ abstract class BasePipelineTest {
             ]
         })
         helper.registerAllowedMethod("buildDiscarder", [Object])
-        helper.registerAllowedMethod("skipStagesAfterUnstable")
         helper.registerAllowedMethod("checkout", [Map])
         helper.registerAllowedMethod("choice", [Map])
         helper.registerAllowedMethod('cifsPublisher', [Map], {true})
@@ -203,6 +202,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod('sh', [String], { args -> helper.runSh(args) })
         helper.registerAllowedMethod('sh', [Map], { args -> helper.runSh(args) })
         helper.registerAllowedMethod('skipDefaultCheckout')
+        helper.registerAllowedMethod("skipStagesAfterUnstable")
         helper.registerAllowedMethod('sleep')
         helper.registerAllowedMethod('specific', [String])
         helper.registerAllowedMethod('sshPublisher', [Map], {true})

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -156,6 +156,7 @@ abstract class BasePipelineTest {
             println(message)
         })
         helper.registerAllowedMethod("error", [String], { updateBuildStatus('FAILURE') })
+        helper.registerAllowedMethod('fileExists', [String], { String arg -> helper.fileExists(arg) })
         helper.registerAllowedMethod("gatlingArchive")
         helper.registerAllowedMethod("gitlabBuilds", [Map, Closure])
         helper.registerAllowedMethod("gitlabCommitStatus", [String, Closure], { String name, Closure c ->

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -1,5 +1,7 @@
 package com.lesfurets.jenkins.unit
 
+import com.sun.org.apache.xpath.internal.operations.Bool
+
 import static com.lesfurets.jenkins.unit.MethodSignature.method
 
 import java.lang.reflect.Method
@@ -107,6 +109,8 @@ class PipelineTestHelper {
 
     /** Let scripts and library classes access global vars (env, currentBuild) */
     protected Binding binding
+
+    Map<String, Boolean> mockFileExistsResults = [:]
 
     Map<String, String> mockReadFileOutputs = [:]
 
@@ -299,6 +303,7 @@ class PipelineTestHelper {
         gse.setConfig(configuration)
 
         mockScriptOutputs.clear()
+        mockFileExistsResults.clear()
         mockReadFileOutputs.clear()
         return this
     }
@@ -566,6 +571,14 @@ class PipelineTestHelper {
         } else {
             return closure.call(*args)
         }
+    }
+
+    void addFileExistsMock(String file, Boolean result) {
+        mockFileExistsResults[file] = result
+    }
+
+    Boolean fileExists(String arg) {
+        return mockFileExistsResults[arg] ?: false
     }
 
     void addReadFileMock(String file, String contents) {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -39,13 +39,25 @@ class PipelineTestHelperTest {
     void readFile() {
         // given:
         def helper = new PipelineTestHelper()
-        helper.addReadFileMock('test', 'contents')
+        helper.addFileExistsMock('test', true)
 
         // when:
-        def output = helper.readFile('test')
+        def result = helper.fileExists('test')
 
         // then:
-        Assertions.assertThat(output).isEqualTo('contents')
+        Assertions.assertThat(result).isTrue()
+    }
+
+    @Test
+    void readFileNotMocked() {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def result = helper.fileExists('test')
+
+        // then:
+        Assertions.assertThat(result).isFalse()
     }
 
     @Test

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -36,7 +36,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void readFile() throws Exception {
+    void readFile() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addReadFileMock('test', 'contents')
@@ -49,7 +49,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void readFileWithMap() throws Exception {
+    void readFileWithMap() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addReadFileMock('test', 'contents')
@@ -62,7 +62,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void readFileWithNoMockOutput() throws Exception {
+    void readFileWithNoMockOutput() {
         // given:
         def helper = new PipelineTestHelper()
 
@@ -74,7 +74,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runSh() throws Exception {
+    void runSh() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd', '/foo/bar', 0)
@@ -87,7 +87,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = Exception)
-    void runShWithScriptFailure() throws Exception {
+    void runShWithScriptFailure() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('evil', '/foo/bar', 666)
@@ -99,7 +99,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithStdout() throws Exception {
+    void runShWithStdout() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd', '/foo/bar', 0)
@@ -112,7 +112,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithReturnCode() throws Exception {
+    void runShWithReturnCode() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd', '/foo/bar', 0)
@@ -125,7 +125,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithNonZeroReturnCode() throws Exception {
+    void runShWithNonZeroReturnCode() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('evil', '/foo/bar', 666)
@@ -138,7 +138,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithCallback() throws Exception {
+    void runShWithCallback() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -153,7 +153,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = Exception)
-    void runShWithCallbackScriptFailure() throws Exception {
+    void runShWithCallbackScriptFailure() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('evil') { script ->
@@ -167,7 +167,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithCallbackStdout() throws Exception {
+    void runShWithCallbackStdout() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -182,7 +182,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithCallbackReturnCode() throws Exception {
+    void runShWithCallbackReturnCode() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -197,7 +197,7 @@ class PipelineTestHelperTest {
     }
 
     @Test
-    void runShWithCallbackNonZeroReturnCode() throws Exception {
+    void runShWithCallbackNonZeroReturnCode() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -212,7 +212,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = IllegalArgumentException)
-    void runShWithCallbackOutputNotMap() throws Exception {
+    void runShWithCallbackOutputNotMap() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -226,7 +226,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = IllegalArgumentException)
-    void runShWithCallbackNoStdoutKey() throws Exception {
+    void runShWithCallbackNoStdoutKey() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -240,7 +240,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = IllegalArgumentException)
-    void runShWithCallbackNoExitValueKey() throws Exception {
+    void runShWithCallbackNoExitValueKey() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('pwd') { script ->
@@ -254,7 +254,7 @@ class PipelineTestHelperTest {
     }
 
     @Test()
-    void runShWithoutMockOutput() throws Exception {
+    void runShWithoutMockOutput() {
         // given:
         def helper = new PipelineTestHelper()
 
@@ -266,7 +266,7 @@ class PipelineTestHelperTest {
     }
 
     @Test()
-    void runShWithoutMockOutputAndReturnStatus() throws Exception {
+    void runShWithoutMockOutputAndReturnStatus() {
         // given:
         def helper = new PipelineTestHelper()
 
@@ -278,7 +278,7 @@ class PipelineTestHelperTest {
     }
 
     @Test()
-    void runShWithoutMockOutputForGitRevParse() throws Exception {
+    void runShWithoutMockOutputForGitRevParse() {
         // given:
         def helper = new PipelineTestHelper()
 
@@ -290,7 +290,7 @@ class PipelineTestHelperTest {
     }
 
     @Test(expected = IllegalArgumentException)
-    void runShWithBothStatusAndStdout() throws Exception {
+    void runShWithBothStatusAndStdout() {
         // given:
         def helper = new PipelineTestHelper()
 


### PR DESCRIPTION
This PR provides a solution to the problems discussed in #306, by allowing users
to register filenames with a desired result for the mock.
