### PR TITLE
set empty map for 'params'  in binding

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -291,7 +291,9 @@ abstract class BasePipelineTest {
         ])
         binding.setVariable('docker', new DockerMock())
         binding.setVariable('env', [:])
+        binding.setVariable('params', [:])
         binding.setVariable('scm', [:])
+        
     }
 
     /**

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -293,7 +293,6 @@ abstract class BasePipelineTest {
         binding.setVariable('env', [:])
         binding.setVariable('params', [:])
         binding.setVariable('scm', [:])
-        
     }
 
     /**

--- a/src/test/groovy/com/lesfurets/jenkins/TestParamInit.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestParamInit.groovy
@@ -1,0 +1,14 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Test
+
+class TestParamInit extends BasePipelineTest {
+
+    @Test
+    void readUndefinedParamNoException() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+        runScript('job/printParams.jenkins')
+    }
+}

--- a/src/test/jenkins/job/printParams.jenkins
+++ b/src/test/jenkins/job/printParams.jenkins
@@ -1,0 +1,1 @@
+print params.FOO


### PR DESCRIPTION
without this. calling addParam() fails