### PR TITLE
Adding unzip mock

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -224,6 +224,7 @@ abstract class BasePipelineTest {
         helper.registerAllowedMethod('tool', [Map], { t -> "${t.name}_HOME" })
         helper.registerAllowedMethod("unstable", [String], { updateBuildStatus('UNSTABLE') })
         helper.registerAllowedMethod('unstash', [Map])
+        helper.registerAllowedMethod('unzip', [Map])
         helper.registerAllowedMethod('usernamePassword', [Map], usernamePasswordInterceptor)
         helper.registerAllowedMethod('waitUntil', [Closure])
         helper.registerAllowedMethod("warnError", [String, Closure], { String arg, Closure c ->


### PR DESCRIPTION
This commit adds a mocked method for 'unzip'.  This will help when someone needs to use the unzip step, making it so they don't have to mock it for the test to succeed.

I used the writeFile mock as a template since it does something similar to unzip.