### PR TITLE
Fix the buildingTag() method's support

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -10,7 +10,7 @@ class WhenDeclaration extends GenericPipelineDeclaration {
 
     AnyOfDeclaration anyOf
     NotDeclaration not
-    Boolean buildingTag = false
+    Boolean buildingTag
     String branch
     String tag
     Closure<Boolean> expression
@@ -66,7 +66,7 @@ class WhenDeclaration extends GenericPipelineDeclaration {
             branchCheck = antPathMatcher.match(branch, delegate.env.BRANCH_NAME)
         }
         if (buildingTag) {
-            tagCheck = delegate.env.containsKey(TAG_NAME)
+            tagCheck = delegate?.env?.containsKey("TAG_NAME")
         }
         if (tag) {
             tagCheck = delegate.env.TAG_NAME =~ tag

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -173,6 +173,23 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void when_buildingTag() throws Exception {
+        addEnvVar('TAG_NAME', 'release-1.0.0')
+        runScript('Tag_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Generating Release Notes')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_buildingTag_not() throws Exception {
+        // no TAG_NAME variable defined
+        runScript('Tag_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Skipping stage Example Release Notes') // No stage bound to a "buildingTag()" condition
+        assertCallStack().contains('Skipping stage Example Deploy') // No stage bound to a "tag <arg>" condition
+        assertJobStatusSuccess()
+    }
+
     @Test void when_tag() throws Exception {
         addEnvVar('TAG_NAME', 'v1.1.1')
         runScript('Tag_Jenkinsfile')

--- a/src/test/jenkins/jenkinsfiles/Tag_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Tag_Jenkinsfile
@@ -11,7 +11,15 @@ pipeline {
                 tag 'v*'
             }
             steps {
-                echo 'Deploying'
+                echo 'Deploying only tags matching the pattern v*'
+            }
+        }
+        stage('Example Release Notes') {
+            when {
+                buildingTag()
+            }
+            steps {
+                echo 'Generating Release Notes for any tag'
             }
         }
     }


### PR DESCRIPTION
This PR fixes #330.

It introduces the following changes:

- Add 1 test case to validate that the method `buildingTag()` works as expected when testing
- Add 1 test case to cross-verify the "no tag" case with both `tag` and `buildingTag()` instructions
- Fix the bug related to a mis-usage of the containsKey() method

Thanks for this great project folks! Do not hesitate to criticize the content of this PR as I'm learning a bit more Groovy by reading this codebase and trying to fix the bug, so I might do terrible things...

Signed-off-by: dduportal <damien.duportal@gmail.com>