### PR TITLE
Remove default values from git plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This test will print the call stack of the execution :
          exampleJob.load(src/test/jenkins/lib/utils.jenkins)
             utils.run()
          exampleJob.stage(Checkout, groovy.lang.Closure)
-            exampleJob.checkout({$class=GitSCM, branches=[{name=feature_test}], doGenerateSubmoduleConfigurations=false, extensions=[], submoduleCfg=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
+            exampleJob.checkout({$class=GitSCM, branches=[{name=feature_test}], extensions=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
             utils.currentRevision()
                utils.sh({returnStdout=true, script=git rev-parse HEAD})
          exampleJob.gitlabBuilds({builds=[build, test]}, groovy.lang.Closure)


### PR DESCRIPTION
Default values for submodule configuration generation are ignored in git plugin 4.6.0.  Changes from the default values are untested and expected to be unworkable in earlier plugin versions.

Remove those settings to reduce "noise"