### PR TITLE
Remove obsolete doGenerateSubmoduleConfigurations

### DIFF
--- a/src/test/groovy/com/lesfurets/jenkins/TestJenkinsFile.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestJenkinsFile.groovy
@@ -35,9 +35,7 @@ class TestJenkinsFile extends BaseRegressionTest {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/groovy/com/lesfurets/jenkins/TestParallelJob.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestParallelJob.groovy
@@ -15,9 +15,7 @@ class TestParallelJob extends BasePipelineTest {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/groovy/com/lesfurets/jenkins/TestParallelJobCPS.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestParallelJobCPS.groovy
@@ -16,9 +16,7 @@ class TestParallelJobCPS extends BasePipelineTestCPS {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegression.groovy
@@ -17,9 +17,7 @@ class TestRegression extends BaseRegressionTestCPS {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/groovy/com/lesfurets/jenkins/TestSerialization.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestSerialization.groovy
@@ -16,9 +16,7 @@ class TestSerialization extends BasePipelineTest {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/groovy/com/lesfurets/jenkins/TestSerializationCPS.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestSerializationCPS.groovy
@@ -18,9 +18,7 @@ class TestSerializationCPS extends BasePipelineTestCPS {
         binding.setVariable('scm', [
                         $class                           : 'GitSCM',
                         branches                         : [[name: scmBranch]],
-                        doGenerateSubmoduleConfigurations: false,
                         extensions                       : [],
-                        submoduleCfg                     : [],
                         userRemoteConfigs                : [[
                                                                             credentialsId: 'gitlab_git_ssh',
                                                                             url          : 'github.com/lesfurets/JenkinsPipelineUnit.git'

--- a/src/test/resources/callstacks/TestJenkinsFile_develop.txt
+++ b/src/test/resources/callstacks/TestJenkinsFile_develop.txt
@@ -1,7 +1,7 @@
    Jenkinsfile.run()
       Jenkinsfile.stage(Build, groovy.lang.Closure)
          Jenkinsfile.node(groovy.lang.Closure)
-            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=develop}], doGenerateSubmoduleConfigurations=false, extensions=[], submoduleCfg=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
+            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=develop}], extensions=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
             Jenkinsfile.echo(Running mvn verify on branch develop)
             Jenkinsfile.sh(mkdir -p ~/.gnupg)
             Jenkinsfile.file({credentialsId=gpg-pubring, variable=GPG_PUB_RING})

--- a/src/test/resources/callstacks/TestJenkinsFile_feature_.txt
+++ b/src/test/resources/callstacks/TestJenkinsFile_feature_.txt
@@ -1,7 +1,7 @@
    Jenkinsfile.run()
       Jenkinsfile.stage(Build, groovy.lang.Closure)
          Jenkinsfile.node(groovy.lang.Closure)
-            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=feature_}], doGenerateSubmoduleConfigurations=false, extensions=[], submoduleCfg=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
+            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=feature_}], extensions=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
             Jenkinsfile.echo(Running mvn verify on branch feature_)
             Jenkinsfile.sh(mkdir -p ~/.gnupg)
             Jenkinsfile.file({credentialsId=gpg-pubring, variable=GPG_PUB_RING})

--- a/src/test/resources/callstacks/TestJenkinsFile_master.txt
+++ b/src/test/resources/callstacks/TestJenkinsFile_master.txt
@@ -1,7 +1,7 @@
    Jenkinsfile.run()
       Jenkinsfile.stage(Build, groovy.lang.Closure)
          Jenkinsfile.node(groovy.lang.Closure)
-            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=master}], doGenerateSubmoduleConfigurations=false, extensions=[], submoduleCfg=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
+            Jenkinsfile.checkout({$class=GitSCM, branches=[{name=master}], extensions=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
             Jenkinsfile.echo(Running mvn deploy on branch master)
             Jenkinsfile.sh(mkdir -p ~/.gnupg)
             Jenkinsfile.file({credentialsId=gpg-pubring, variable=GPG_PUB_RING})

--- a/src/test/resources/callstacks/TestRegression_example.txt
+++ b/src/test/resources/callstacks/TestRegression_example.txt
@@ -7,7 +7,7 @@
          exampleJob.load(src/test/jenkins/lib/properties.jenkins)
             properties.run()
          exampleJob.stage(Checkout, groovy.lang.Closure)
-            exampleJob.checkout({$class=GitSCM, branches=[{name=feature_test}], doGenerateSubmoduleConfigurations=false, extensions=[], submoduleCfg=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
+            exampleJob.checkout({$class=GitSCM, branches=[{name=feature_test}], extensions=[], userRemoteConfigs=[{credentialsId=gitlab_git_ssh, url=github.com/lesfurets/JenkinsPipelineUnit.git}]})
             utils.currentRevision()
                utils.sh({returnStdout=true, script=git rev-parse HEAD})
          exampleJob.gitlabBuilds({builds=[build, test]}, groovy.lang.Closure)


### PR DESCRIPTION
Git plugin versions prior to 4.6.0 included an experiment in submodule configuration that was intentionally excluded from the user interface.  However, the Pipeline uses introspection to identify the DataBoundConstructor and its arguments.  Because that experiment was part of the arguments to the constructor, they were made visible to pipeline users through the Pipeline Syntax snippet generator.

Git plugin 4.6.0 removes those experimental arguments from the snippet generator.  Would be good to also remove them from other source code when we can.  The arguments are still supported, but the values assigned to those arguments are ignored.