### PR TITLE
chore: No more Release Release in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,4 +2,4 @@
 _extends: jenkinsci/.github
 version-template: $MAJOR.$MINOR
 tag-template: v$NEXT_MINOR_VERSION
-name-template: Release $NEXT_MINOR_VERSION
+name-template: $NEXT_MINOR_VERSION


### PR DESCRIPTION
in the page title on github:

![image](https://user-images.githubusercontent.com/21194782/110535348-0f404300-8118-11eb-88f7-d292f51e6903.png)
