### PR TITLE
Fix incorrect filename in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ node {
 ```groovy
 @Test
 void exampleReadFileTest() {
-    helper.addFileExistsMock('fileExists', true)
+    helper.addFileExistsMock('output', true)
     helper.addReadFileMock('output', 'FAILED!!!')
     runScript("Jenkinsfile")
     assertJobStatusFailure()


### PR DESCRIPTION
Just fixing a small error in the README.