### PR TITLE
Avoid using default encoding

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/RegressionTestHelper.groovy
@@ -33,7 +33,7 @@ class RegressionTestHelper {
         String callStack = helper.callStack.join('\n') + '\n'
         assertThat(callStack.normalize())
                         .as('If you intended to update the callstack, use JVM parameter -D%s=true', PIPELINE_STACK_WRITE)
-                        .isEqualTo(referenceFile.text.normalize())
+                        .isEqualTo(referenceFile.getText(StandardCharsets.UTF_8.name()).normalize())
     }
 
     private static writeStackToFile(File referenceFile, PipelineTestHelper helper) {


### PR DESCRIPTION
On Windows uses Windows-1252 leading to problems for e.g. German Umlaute

See incomplete #358