### PR TITLE
Include tag support in anyOf declarative

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AnyOfDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AnyOfDeclaration.groovy
@@ -8,9 +8,14 @@ import static groovy.lang.Closure.DELEGATE_FIRST
 
 class AnyOfDeclaration extends WhenDeclaration {
 
+    List<String> tags = []
     List<String> branches = []
     List<Boolean> expressions = []
     List<AllOfDeclaration> allOfs = []
+
+    def tag(String name) {
+        this.tags.add(name)
+    }
 
     def branch(String name) {
         this.branches.add(name)
@@ -36,6 +41,12 @@ class AnyOfDeclaration extends WhenDeclaration {
         def results = []
 
         AntPathMatcher antPathMatcher = new AntPathMatcher()
+
+        if (this.tags.size() > 0) {
+            tags.each { tag ->
+                results.add(antPathMatcher.match(tag, delegate.env.TAG_NAME))
+            }
+        }
 
         if (this.branches.size() > 0) {
             branches.each { branch ->

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -142,6 +142,30 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void when_anyOf_tag_version_pattern() throws Exception {
+        addEnvVar('TAG_NAME', 'version-X.Y.Z')
+        runScript('AnyOf_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Executing anyOf with tag')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_anyOf_tag_release_pattern() throws Exception {
+        addEnvVar('TAG_NAME', 'release-X.Y.Z')
+        runScript('AnyOf_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Executing anyOf with tag')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_anyOf_tag_release_pattern_main_not() throws Exception {
+        addEnvVar('TAG_NAME', 'releaseX.Y.Z')
+        runScript('AnyOf_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Skipping stage Example anyOf tag')
+        assertJobStatusSuccess()
+    }
+
     @Test void when_anyOf_expression_not() throws Exception {
         addEnvVar('SHOULD_EXECUTE', 'false')
         runScript('AnyOf_Jenkinsfile')

--- a/src/test/jenkins/jenkinsfiles/AnyOf_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/AnyOf_Jenkinsfile
@@ -33,5 +33,16 @@ pipeline {
                 echo 'Executing anyOf with branch'
             }
         }
+        stage('Example anyOf tags') {
+            when {
+                anyOf {
+                    tag 'release-*'
+                    tag 'version-*'
+                }
+            }
+            steps {
+                echo 'Executing anyOf with tag'
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The anyOf declaration didn't support `tag` usage, only `branch` and `expression`. This PR includes that functionality based on the branch implementation.

reference PRs: 
https://github.com/jenkinsci/JenkinsPipelineUnit/pull/264
https://github.com/jenkinsci/JenkinsPipelineUnit/pull/278
https://github.com/jenkinsci/JenkinsPipelineUnit/pull/343

original issue:
https://github.com/jenkinsci/JenkinsPipelineUnit/issues/227

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
