### PR TITLE
Make CLONE_TIMEOUT a value in minutes, not seconds

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/GitSource.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/GitSource.groovy
@@ -26,7 +26,7 @@ class GitSource implements SourceRetriever {
                         .inheritIO()
                         .directory(target)
         def proc = processBuilder.start()
-        proc.waitFor(CLONE_TIMEOUT, TimeUnit.SECONDS)
+        proc.waitFor(CLONE_TIMEOUT_MIN, TimeUnit.MINUTES)
         proc.exitValue()
         return [fetch.toURI().toURL()]
     }

--- a/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/SourceRetriever.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/SourceRetriever.groovy
@@ -5,7 +5,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 interface SourceRetriever {
 
-    public static final int CLONE_TIMEOUT = 10
+    public static final int CLONE_TIMEOUT_MIN = 10
 
     List<URL> retrieve(String repository, String branch, String targetPath) throws IllegalStateException
 


### PR DESCRIPTION
This matches the behavior of the default timeout for scm-steps, which
also uses 10 minutes. Thanks to @GordonJess for catching this.

Fixes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/373.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
