### PR TITLE
Correct this object in Closure#rehydrate.

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/StageDeclaration.groovy
@@ -61,7 +61,7 @@ class StageDeclaration extends GenericPipelineDeclaration {
                 e.value.execute(delegate)
             }
             if(steps) {
-                Closure stageBody = { agent?.execute(delegate) } >> steps.rehydrate(delegate, this, this)
+                Closure stageBody = { agent?.execute(delegate) } >> steps.rehydrate(delegate, this, delegate)
                 Closure cl = { stage("$name", stageBody) }
                 executeWith(delegate, cl)
             }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -655,4 +655,10 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertCallStack().contains('echo(Hello using custom workspace and empty label)')
         assertJobStatusSuccess()
     }
+
+    @Test void should_scope_this_in_closure() throws Exception {
+        runScript('ThisScope_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('writeFile({file=messages/messages.msg, text=text})')
+    }
 }

--- a/src/test/jenkins/jenkinsfiles/ThisScope_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/ThisScope_Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+    agent any
+    stages {
+        stage('issue#419') {
+            steps {
+                script {
+                    new Messages(this).add("text")
+                }
+            }
+        }
+    }
+}
+
+class Messages implements Serializable {
+    def steps
+
+    Messages(steps) {
+        this.steps = steps
+    }
+
+    def add(String message) {
+        this.steps.writeFile(file: "messages/messages.msg", text: message)
+    }
+}


### PR DESCRIPTION
Closure#rehydrate takes 3 parameters: `delegate`, `owner` and `thisObject`. The owner is not `this`. The change in https://github.com/jenkinsci/JenkinsPipelineUnit/commit/0893a2073981937daf663d9cc8ab9a4dc98934e1 caused a regression between 1.7 and 1.8.

Closes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/419

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

