### PR TITLE
Upgrade to Groovy 2.4.21, fix unsupported target MODULE error.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
   matrix:
   - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+  - JAVA_HOME: C:\Program Files\Java\jdk11
 
 cache:
   - C:\Users\appveyor\.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ configurations {
 }
 
 dependencies {
-    implementation('org.codehaus.groovy:groovy-all:2.4.6')
+    implementation('org.codehaus.groovy:groovy-all:2.4.14')
     implementation('com.cloudbees:groovy-cps:1.12')
     implementation('commons-io:commons-io:2.5')
     implementation('org.apache.ivy:ivy:2.4.0')

--- a/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestHelperSingleton.groovy
@@ -12,11 +12,16 @@ import static org.assertj.core.api.Assertions.assertThat
 
 class TestHelperSingleton extends BasePipelineTest {
 
-    static PipelineTestHelper HELPER
+    static PipelineTestHelper HELPER = new PipelineTestHelper()
 
-    @BeforeClass
-    static void beforeClass() {
-        HELPER = new PipelineTestHelper()
+    TestHelperSingleton() {
+        super(HELPER)
+    }
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
 
         String sharedLibs = this.class.getResource('/libs').getFile()
 
@@ -29,16 +34,7 @@ class TestHelperSingleton extends BasePipelineTest {
                 .build()
 
         HELPER.registerSharedLibrary(library)
-    }
 
-    TestHelperSingleton() {
-        super(HELPER)
-    }
-
-    @Override
-    @Before
-    void setUp() throws Exception {
-        scriptRoots += 'src/test/jenkins'
         super.setUp()
     }
 

--- a/src/test/groovy/com/lesfurets/jenkins/TestRegressionGlobalVar.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestRegressionGlobalVar.groovy
@@ -11,7 +11,7 @@ class TestRegressionGlobalVar extends BaseRegressionTestCPS {
     void setUp() throws Exception {
         scriptRoots += 'src/test/jenkins'
         super.setUp()
-        helper.registerAllowedMethod("doWithProperties", [Properties.class], null)
+        helper.registerAllowedMethod("doWithProperties", [TreeMap.class], null)
     }
 
     @Test

--- a/src/test/jenkins/job/globalVar.jenkins
+++ b/src/test/jenkins/job/globalVar.jenkins
@@ -10,7 +10,7 @@ node() {
 
         p.setProperty('PROP_1', 'VAL_1')
 
-        doWithProperties(p)
+        doWithProperties(new TreeMap(p))
     }
 
     stage('Two') {
@@ -19,7 +19,7 @@ node() {
 
         p.setProperty('PROP_2', 'VAL_2')
 
-        doWithProperties(p)
+        doWithProperties(new TreeMap(p))
     }
 }
 

--- a/src/test/resources/callstacks/TestRegressionGlobalVar_globalVar.txt
+++ b/src/test/resources/callstacks/TestRegressionGlobalVar_globalVar.txt
@@ -5,4 +5,4 @@
             globalVar.doWithProperties({PROP_1=VAL_1})
          globalVar.stage(Two, groovy.lang.Closure)
             globalVar.echo(Stage Two)
-            globalVar.doWithProperties({PROP_2=VAL_2, PROP_1=VAL_1})
+            globalVar.doWithProperties({PROP_1=VAL_1, PROP_2=VAL_2})


### PR DESCRIPTION
Groovy 2.4.12 implemented support for target MODULE, whatever that means. Upgraded to the latest version of Groovy 2.4. Added JDK 11 (LTS) to CI.

Had to make two other changes:

- a unit test executed in a, what seems to be, correct order
- calling `getResource` in `@BeforeClass` returns `null`, moved that initialization code in a before block

Fixes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/292.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x]  Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
