### PR TITLE
Add support for alwaysPull in docker agent

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerAgentDeclaration.groovy
@@ -16,6 +16,7 @@ class DockerAgentDeclaration extends GenericPipelineDeclaration {
     String customWorkspace
     boolean reuseNode
     boolean containerPerStageRoot
+    boolean alwaysPull
     String image
 
     def label(final String label) {
@@ -24,6 +25,10 @@ class DockerAgentDeclaration extends GenericPipelineDeclaration {
 
     def args(final String args) {
         this.args = args
+    }
+
+    def alwaysPull(final boolean alwaysPull) {
+        this.alwaysPull = alwaysPull
     }
 
     def registryUrl(final String registryUrl) {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -642,7 +642,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         runScript('Agent_bindings_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('[label:someVar]')
-        assertCallStack().contains('docker:[', ', image:someVar, ', ']')
+        assertCallStack().contains('docker:[', 'image:someVar',)
         assertCallStack().contains('[label:someLabel]')
         assertCallStack().contains('echo(Deploy to someLabel)')
         assertJobStatusSuccess()

--- a/src/test/jenkins/jenkinsfiles/Docker_agentInStep_JenkinsFile
+++ b/src/test/jenkins/jenkinsfiles/Docker_agentInStep_JenkinsFile
@@ -2,7 +2,13 @@ pipeline {
 
     stages {
         stage('Maven Build') {
-            agent { docker { image 'maven' } }
+            agent {
+                docker {
+                    image 'maven'
+                    label 'latest'
+                    alwaysPull true
+                }
+            }
             steps {
                 sh 'mvn install'
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Adds support for the `alwaysPull` attribute of `docker` blocks in declarative pipelines. Fixes #432.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
