### PR TITLE
Align sh mock exception message to AbortException

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -738,7 +738,7 @@ class PipelineTestHelper {
             return exitValue
         }
         if (exitValue != 0) {
-            throw new Exception('Script returned error code: ' + exitValue)
+            throw new Exception('script returned exit code ' + exitValue)
         }
         return null
     }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -98,16 +98,23 @@ class PipelineTestHelperTest {
         Assertions.assertThat(output).isNull()
     }
 
-    @Test(expected = Exception)
+    @Test
     void runShWithScriptFailure() {
         // given:
         def helper = new PipelineTestHelper()
         helper.addShMock('evil', '/foo/bar', 666)
+        Exception caught = null
 
         // when:
-        helper.runSh('evil')
+        try {
+            helper.runSh('evil')
+        } catch (e) {
+            caught = e
+        }
 
         // then: Exception raised
+        Assertions.assertThat(caught).isNotNull()
+        Assertions.assertThat(caught.message).isEqualTo('script returned exit code 666')
     }
 
     @Test


### PR DESCRIPTION
This is necessary for users who need to examine the exception message
from `sh` commands, because the `sh` step's `returnStdout` and
`returnStatus` options are mutually exclusive.

Fixes #455.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
