### PR TITLE
Support map parameter file in fileExists mock

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -643,6 +643,10 @@ class PipelineTestHelper {
         return mockFileExistsResults[arg] ?: false
     }
 
+    Boolean fileExists(Map args) {
+        return mockFileExistsResults[args.file] ?: false
+    }
+
     void addReadFileMock(String file, String contents) {
         mockReadFileOutputs[file] = contents
     }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -61,6 +61,31 @@ class PipelineTestHelperTest {
     }
 
     @Test
+    void readFileMapParameters() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addFileExistsMock('test', true)
+
+        // when:
+        def result = helper.fileExists(file: 'test')
+
+        // then:
+        Assertions.assertThat(result).isTrue()
+    }
+
+    @Test
+    void readFileNotMockedMapParameters() {
+        // given:
+        def helper = new PipelineTestHelper()
+
+        // when:
+        def result = helper.fileExists(file: 'test')
+
+        // then:
+        Assertions.assertThat(result).isFalse()
+    }
+
+    @Test
     void readFileWithMap() {
         // given:
         def helper = new PipelineTestHelper()


### PR DESCRIPTION
Add support for `fileExists` parameter as map: https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#fileexists-verify-if-file-exists-in-workspace

E.g. Jenkinsfile script:
```java
if (fileExists(file: 'test.json')) {
   echo('Hello')
}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


