### PR TITLE
script handlers using patterns

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -735,7 +735,7 @@ class PipelineTestHelper {
         boolean returnStdout = false
         boolean returnStatus = false
 
-        // The `sh` function can be called with either a string, or a map of key/value pairs.
+        // The shell functions can be called with either a string, or a map of key/value pairs.
         if (args instanceof String || args instanceof GString) {
             script = args
         } else if (args instanceof Map) {
@@ -769,13 +769,13 @@ class PipelineTestHelper {
             try {
                 callbackOutput = output.callback(script)
             } catch (GroovyCastException) {
-                throw new IllegalArgumentException("Mocked sh callback for ${script} was not a map")
+                throw new IllegalArgumentException("Mocked shell callback for ${script} was not a map")
             }
             if (!callbackOutput.containsKey('stdout') || !(callbackOutput['stdout'] instanceof String)) {
-                throw new IllegalArgumentException("Mocked sh callback for ${script} did not contain a valid value for the stdout key")
+                throw new IllegalArgumentException("Mocked shell callback for ${script} did not contain a valid value for the stdout key")
             }
             if (!callbackOutput.containsKey('exitValue') || !(callbackOutput['exitValue'] instanceof Integer)) {
-                throw new IllegalArgumentException("Mocked sh callback for ${script} did not contain a valid value for the exitValue key")
+                throw new IllegalArgumentException("Mocked shell callback for ${script} did not contain a valid value for the exitValue key")
             }
             stdout = callbackOutput['stdout']
             exitValue = callbackOutput['exitValue']
@@ -784,7 +784,7 @@ class PipelineTestHelper {
             exitValue = output.exitValue
         }
 
-        // Jenkins also prints the output from sh when returnStdout is true if the script fails
+        // Jenkins also prints the output from the shell when returnStdout is true if the script fails
         if (!returnStdout || exitValue != 0) {
             println stdout
         }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -272,6 +272,39 @@ class PipelineTestHelperTest {
     }
 
     @Test()
+    void runShWithPattern() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock(~/echo\s(.*)/) { String script, String arg ->
+            assertThat(script).isEqualTo('echo foo')
+            assertThat(arg).isEqualTo('foo')
+            return [stdout: '', exitValue: 2]
+        }
+
+        // when:
+        def status = helper.runSh(returnStatus: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
+    @Test()
+    void runShWithDefaultPattern() {
+        // given:
+        helper.addShMock(~/.*/) { String script, String ...args ->
+            assertThat(script).isEqualTo('echo foo')
+            assertThat(args as List).isEqualTo([])
+            return [stdout: '', exitValue: 2]
+        }
+
+        // when:
+        def status = helper.runSh(returnStatus: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
+    @Test()
     void runShWithoutMockOutput() {
         // given:
 

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -304,6 +304,33 @@ class PipelineTestHelperTest {
         assertThat(output).isEqualTo('')
     }
 
+    @Test()
+    void runShWithDefaultHandler() {
+        // given:
+        helper.addShMock('command', 'ignored', 0)
+        helper.addShMock(null, 'default', 1)
+        helper.addShMock('pwd', 'ignored', 2)
+
+        // when:
+        def status = helper.runSh(script: 'command', returnStatus: true)
+
+        // then:
+        assertThat(status).isEqualTo(1)
+    }
+
+    @Test()
+    void runShWithOverriddenHandler() {
+        // given:
+        helper.addShMock('command', 'base', 1)
+        helper.addShMock('command', 'override', 2)
+
+        // when:
+        def status = helper.runSh(script: 'command', returnStatus: true)
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
     @Test(expected = IllegalArgumentException)
     void runShWithBothStatusAndStdout() {
         // given:


### PR DESCRIPTION
This PR addresses #347. In addition (and that's also the reason this will remain a draft for now), there is a bit of refactoring.

The implementation allows tests like this one:
```
        // given:
        def helper = new PipelineTestHelper()
        helper.addShMock(~/echo\s(.*)/) { String script, String arg ->
            assertThat(script).isEqualTo('echo foo')
            assertThat(arg).isEqualTo('foo')
            return [stdout: '', exitValue: 2]
        }

        // when:
        def status = helper.runSh(returnStatus: true, script: 'echo foo')

        // then:
        assertThat(status).isEqualTo(2)
```

Please review (and possibly cherry-pick) the first two commits in particular, they are just some code refactoring. Once we have found an agreement on those two (or discarded them), I'll tidy up the remaining commits a bit so this actual PR can be addressed.

