### PR TITLE
Generate a default closure in InterceptingGCL

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -18,9 +18,18 @@ class InterceptingGCL extends GroovyClassLoader {
             Map.Entry<MethodSignature, Closure> matchingMethod = helper.allowedMethodCallbacks.find { k, v -> k == signature }
             if (matchingMethod) {
                 // a matching method was registered, replace script method execution call with the registered closure (mock)
-                metaClazz."$scriptMethod.name" = matchingMethod.value ?: {}
+                metaClazz."$scriptMethod.name" = matchingMethod.value ?: defaultClosure(matchingMethod.key.args)
             }
         }
+    }
+
+    static Closure defaultClosure(Class[] args) {
+        String argumentsString = args.inject("") { acc, value ->
+            acc + value.name + " " + "a"*(acc.count(',') + 1) + ","}
+        String argumentsStringWithoutComma = argumentsString.size() > 0 ?
+                argumentsString.substring(0, argumentsString.length()-1) : argumentsString
+        String closureString = "{$argumentsStringWithoutComma -> }"
+        return (Closure)new GroovyShell().evaluate(closureString)
     }
 
     PipelineTestHelper helper

--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -24,8 +24,10 @@ class InterceptingGCL extends GroovyClassLoader {
     }
 
     static Closure defaultClosure(Class[] args) {
+        int maxLength = 254
+        if (args.length > maxLength) { throw new IllegalArgumentException("Only $maxLength arguments allowed")}
         String argumentsString = args.inject("") { acc, value ->
-            acc + value.name + " " + "a"*(acc.count(',') + 1) + ","}
+            return "${acc}${value.name} ${'a'*(acc.count(',') + 1)},"}
         String argumentsStringWithoutComma = argumentsString.size() > 0 ?
                 argumentsString.substring(0, argumentsString.length()-1) : argumentsString
         String closureString = "{$argumentsStringWithoutComma -> }"

--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -25,9 +25,12 @@ class InterceptingGCL extends GroovyClassLoader {
 
     static Closure defaultClosure(Class[] args) {
         int maxLength = 254
-        if (args.length > maxLength) { throw new IllegalArgumentException("Only $maxLength arguments allowed")}
+        if (args.length > maxLength) {
+            throw new IllegalArgumentException("Only $maxLength arguments allowed")
+        }
         String argumentsString = args.inject("") { acc, value ->
-            return "${acc}${value.name} ${'a'*(acc.count(',') + 1)},"}
+            return "${acc}${value.name} ${'a'*(acc.count(',') + 1)},"
+        }
         String argumentsStringWithoutComma = argumentsString.size() > 0 ?
                 argumentsString.substring(0, argumentsString.length()-1) : argumentsString
         String closureString = "{$argumentsStringWithoutComma -> }"

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestMockLocalFunction.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestMockLocalFunction.groovy
@@ -5,6 +5,9 @@ import org.junit.Test
 
 class TestMockLocalFunction extends DeclarativePipelineTest {
 
+    private static String SCRIPT_NO_PARAMS = "Mock_existing_function_Jenkinsfile"
+    private static String SCRIPT_PARAMS = SCRIPT_NO_PARAMS + "_params"
+
     @Before
     @Override
     void setUp() throws Exception {
@@ -14,13 +17,24 @@ class TestMockLocalFunction extends DeclarativePipelineTest {
     }
 
     @Test(expected=MissingMethodException.class)
-    void should_execute_with_errors() {
-        runScript("Mock_existing_function_Jenkinsfile")
+    void no_params_should_execute_with_errors() {
+        runScript(SCRIPT_NO_PARAMS)
     }
 
     @Test
-    void should_execute_without_errors() {
+    void no_params_should_execute_without_errors() {
         helper.registerAllowedMethod("runFunc")
-        runScript("Mock_existing_function_Jenkinsfile")
+        runScript(SCRIPT_NO_PARAMS)
+    }
+
+    @Test(expected=MissingMethodException.class)
+    void params_should_execute_with_errors() {
+        runScript(SCRIPT_PARAMS)
+    }
+
+    @Test
+    void params_should_execute_without_errors() {
+        helper.registerAllowedMethod("runFuncWithParam", [String])
+        runScript(SCRIPT_PARAMS)
     }
 }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestMockLocalFunction.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestMockLocalFunction.groovy
@@ -1,5 +1,9 @@
 package com.lesfurets.jenkins.unit.declarative
 
+import static org.assertj.core.api.Assertions.assertThat
+
+import org.junit.runners.JUnit4
+import com.lesfurets.jenkins.unit.InterceptingGCL
 import org.junit.Before
 import org.junit.Test
 
@@ -36,5 +40,34 @@ class TestMockLocalFunction extends DeclarativePipelineTest {
     void params_should_execute_without_errors() {
         helper.registerAllowedMethod("runFuncWithParam", [String])
         runScript(SCRIPT_PARAMS)
+    }
+
+    @Test
+    void default_closure_empty() {
+        Class[] args = []
+        default_closure_parameter_check(args)
+    }
+
+    @Test
+    void default_closure_different_args() {
+        Class[] args = [Arrays.class, JUnit4.class, InterceptingGCL.class, String.class, Integer.class]
+        default_closure_parameter_check(args)
+    }
+
+    @Test
+    void default_closure_max_args() {
+        Class[] args = (1..254).collect{ String.class }
+        default_closure_parameter_check(args)
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    void default_closure_exceeded_args() {
+        Class[] args = (1..500).collect{ String.class }
+        default_closure_parameter_check(args)
+    }
+
+    private static void default_closure_parameter_check(Class[] args) {
+        Closure closure = InterceptingGCL.defaultClosure(args)
+        assertThat(closure.getParameterTypes()).isEqualTo(args)
     }
 }

--- a/src/test/jenkins/jenkinsfiles/Mock_existing_function_Jenkinsfile_params
+++ b/src/test/jenkins/jenkinsfiles/Mock_existing_function_Jenkinsfile_params
@@ -1,0 +1,16 @@
+pipeline {
+    agent { node { label 'test1' } }
+    stages {
+        stage('sdfsdf') {
+            steps {
+                githubNotify status: 'PENDING', context: 'Pipeline'
+                runFuncWithParam("one")
+            }
+        }
+    }
+}
+
+def runFuncWithParam(String oneString) {
+    echo "inside runFuncWithParam"
+    doSomeStuffWithParam()
+}


### PR DESCRIPTION
In case a method is matched with null value closure, the default generated closure is {}.

This does not work when the method has more parameters, so the approach of generating a default closure using dynamic compilation was taken.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Solves comments in issue #461 
