### PR TITLE
Set currentBuild.currentResult in updateBuildStatus

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -328,6 +328,7 @@ abstract class BasePipelineTest {
      */
     void updateBuildStatus(String status) {
         binding.getVariable('currentBuild').result = status
+        binding.getVariable('currentBuild').currentResult = status
     }
 
     /**

--- a/src/test/groovy/com/lesfurets/jenkins/unit/BasePipelineTestTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/BasePipelineTestTest.groovy
@@ -1,0 +1,30 @@
+package com.lesfurets.jenkins.unit
+
+import static org.assertj.core.api.Assertions.assertThat
+
+import org.junit.Before
+import org.junit.Test
+
+class BasePipelineTestTest extends BasePipelineTest {
+    @Before
+    @Override
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins/jenkinsfiles'
+        scriptExtension = ''
+        super.setUp()
+    }
+
+    @Test
+    void buildStatusFailure() {
+        runScript('BuildStatus_Failure_Jenkinsfile')
+        assertThat(binding.getVariable('currentBuild').result).isEqualTo('FAILURE')
+        assertThat(binding.getVariable('currentBuild').currentResult).isEqualTo('FAILURE')
+    }
+
+    @Test
+    void buildStatusSuccess() {
+        runScript('BuildStatus_Success_Jenkinsfile')
+        assertThat(binding.getVariable('currentBuild').result).isEqualTo('SUCCESS')
+        assertThat(binding.getVariable('currentBuild').currentResult).isEqualTo('SUCCESS')
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/BuildStatus_Failure_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/BuildStatus_Failure_Jenkinsfile
@@ -1,0 +1,5 @@
+node {
+    stage('Failure') {
+        error 'should fail'
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/BuildStatus_Success_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/BuildStatus_Success_Jenkinsfile
@@ -1,0 +1,5 @@
+node {
+    stage('Success') {
+        echo 'should succeed'
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Set `currentBuild.currentResult` when updating build status in `BasePipelineTest.updateBuildStatus`. Fixes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/516.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
