### PR TITLE
Make bindings accessible in SharedLibrary classes.

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/InterceptingGCL.groovy
@@ -12,6 +12,9 @@ class InterceptingGCL extends GroovyClassLoader {
         metaClazz.static.invokeMethod = helper.getMethodInterceptor()
         metaClazz.methodMissing = helper.getMethodMissingInterceptor()
         metaClazz.getEnv = {return binding.env}
+        binding.variables.forEach { String property, Object value ->
+            metaClazz."$property" = metaClazz."$property" ?: value
+        }
         // find and replace script method closure with any matching allowed method closure
         metaClazz.methods.forEach { scriptMethod ->
             def signature = method(scriptMethod.name, scriptMethod.nativeParameterTypes)

--- a/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryAccessibleParams.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryAccessibleParams.groovy
@@ -6,12 +6,15 @@ import org.junit.Test
 
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
 import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+import static org.assertj.core.api.Assertions.assertThat
 
 class TestSharedLibraryAccessibleParams extends DeclarativePipelineTest {
 
     private final String JOB_NAME = "params_not_accessible"
     private final String JOB_PATH = "job/library/${JOB_NAME}.jenkins"
     private final String LIB_DIR = this.class.getResource("/libs/$JOB_NAME").getFile()
+    private final String BINDING_VAR = "testVar"
+    private final String BINDING_VAL = "notBroken"
 
     @Override
     @Before
@@ -30,13 +33,23 @@ class TestSharedLibraryAccessibleParams extends DeclarativePipelineTest {
 
     @Test
     void accessible_params_test() {
-        binding.setVariable('testVar', 'notBroken')
-        runScript(JOB_PATH)
-        assertJobStatusSuccess()
+        run_test_with_bindings {assertJobStatusSuccess()}
+    }
+
+    @Test
+    void change_binding_test() {
+        run_test_with_bindings {assertThat(binding.getVariable(BINDING_VAR)).isNotEqualTo(BINDING_VAL)}
     }
 
     @Test(expected = MissingPropertyException.class)
     void not_accessible_params_test() {
         runScript(JOB_PATH)
     }
+
+    private void run_test_with_bindings(Closure assertion) {
+        binding.setVariable(BINDING_VAR, BINDING_VAL)
+        runScript(JOB_PATH)
+        assertion()
+    }
+
 }

--- a/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryAccessibleParams.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryAccessibleParams.groovy
@@ -1,0 +1,42 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.declarative.DeclarativePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+
+class TestSharedLibraryAccessibleParams extends DeclarativePipelineTest {
+
+    private final String JOB_NAME = "params_not_accessible"
+    private final String JOB_PATH = "job/library/${JOB_NAME}.jenkins"
+    private final String LIB_DIR = this.class.getResource("/libs/$JOB_NAME").getFile()
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+        def library = library().name(JOB_NAME)
+                .retriever(projectSource(LIB_DIR))
+                .defaultVersion("master")
+                .targetPath(LIB_DIR)
+                .allowOverride(true)
+                .implicit(false)
+                .build()
+        helper.registerSharedLibrary(library)
+    }
+
+    @Test
+    void accessible_params_test() {
+        binding.setVariable('testVar', 'notBroken')
+        runScript(JOB_PATH)
+        assertJobStatusSuccess()
+    }
+
+    @Test(expected = MissingPropertyException.class)
+    void not_accessible_params_test() {
+        runScript(JOB_PATH)
+    }
+}

--- a/src/test/jenkins/job/library/params_not_accessible.jenkins
+++ b/src/test/jenkins/job/library/params_not_accessible.jenkins
@@ -6,6 +6,7 @@ pipeline {
         stage('Test stage'){
             steps {
                 out = new LibClass().getX()
+                testVar = 'changedValue'
                 echo "Printing ${out}"
             }
         }

--- a/src/test/jenkins/job/library/params_not_accessible.jenkins
+++ b/src/test/jenkins/job/library/params_not_accessible.jenkins
@@ -1,0 +1,13 @@
+@Library('params_not_accessible')
+import org.test.LibClass
+
+pipeline {
+    stages {
+        stage('Test stage'){
+            steps {
+                out = new LibClass().getX()
+                echo "Printing ${out}"
+            }
+        }
+    }
+}

--- a/src/test/resources/libs/params_not_accessible/src/org/test/LibClass.groovy
+++ b/src/test/resources/libs/params_not_accessible/src/org/test/LibClass.groovy
@@ -1,0 +1,7 @@
+package org.test
+
+class LibClass {
+    def getX() {
+        return testVar
+    }
+}


### PR DESCRIPTION
For the library loading a Pogo is instantiated, which has a different implementation while getting an object.

This POGO does not read the bindings. In the PogoMetaClassGetPropertySite the implementation can be found. This throws a runtime exception, which suits well for the common purposes, but not when we try to emulate the Jenkins shared library behaviour.

So the workaround is to add the bindings as properties dynamically inside InterceptingGCL.

This change tries to solve the issue #478 

<!-- Please describe your pull request here. -->

- [ X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ X] Link to relevant issues in GitHub or Jira
- [ X] Link to relevant pull requests, esp. upstream and downstream changes
- [ X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
