### PR TITLE
Fix for shared lib and params variables being null in environment section

### DIFF
--- a/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryEnvVariable.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestSharedLibraryEnvVariable.groovy
@@ -1,0 +1,51 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.declarative.DeclarativePipelineTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+
+class TestSharedLibraryEnvVariable extends DeclarativePipelineTest {
+
+    String sharedLibVars = this.class.getResource("/libs/env_var_not_defined").getFile()
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+
+        super.setUp()
+
+        def library = library().name("env_var_not_defined")
+                .retriever(projectSource(sharedLibVars))
+                .defaultVersion("master")
+                .targetPath(sharedLibVars)
+                .allowOverride(true)
+                .implicit(false)
+                .build()
+        helper.registerSharedLibrary(library)
+    }
+
+    @Test
+    void "test lib var not defined in env"() {
+
+        runScript("job/library/test_lib_var_not_defined_in_env.jenkins")
+
+        def prop1 = binding.env["prop1"]
+        Assert.assertEquals("magic", prop1)
+    }
+
+    @Test
+    void "test params not defined in env"() {
+        def version =  "1.2.0"
+        addParam("VERSION", version)
+
+        runScript("job/library/test_params_not_defined_in_env.jenkins")
+
+        def versionFromEnv = binding.env["VERSION"]
+        Assert.assertEquals(version, versionFromEnv.toString())
+    }
+}

--- a/src/test/jenkins/job/library/test_lib_var_not_defined_in_env.jenkins
+++ b/src/test/jenkins/job/library/test_lib_var_not_defined_in_env.jenkins
@@ -1,0 +1,16 @@
+@Library("env_var_not_defined") _
+
+pipeline {
+
+    environment {
+        prop1 = envHelper.property1()
+    }
+
+    stages {
+        stage('Test stage'){
+            steps {
+                echo "prop1=${env.prop1}"
+            }
+        }
+    }
+}

--- a/src/test/jenkins/job/library/test_params_not_defined_in_env.jenkins
+++ b/src/test/jenkins/job/library/test_params_not_defined_in_env.jenkins
@@ -1,0 +1,17 @@
+pipeline {
+    agent none
+    parameters {
+        string name: 'VERSION', defaultValue: 'default-version'
+    }
+    environment {
+        VERSION = "${params.VERSION}"
+    }
+    stages {
+        stage('Print VERSION') {
+            steps {
+                echo env.VERSION // null when VERSION = "${VERSION}"
+                echo VERSION // default-version when VERSION = "${VERSION}"
+            }
+        }
+    }
+}

--- a/src/test/resources/libs/env_var_not_defined/vars/envHelper.groovy
+++ b/src/test/resources/libs/env_var_not_defined/vars/envHelper.groovy
@@ -1,0 +1,4 @@
+
+def property1() {
+    return "magic"
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Hello, this is a possible fix for #387.

### Analysis of the issue 
According to Groovy's metaprogramming rules (https://docs.groovy-lang.org/latest/html/documentation/core-metaprogramming.html) Groovy calls `getProperty` method on `Closure` which in turn tries to get this property from the delegate (in our case this is a `Map`) and when the property is not found it tries to find the property on the owner object. 
Here's code snippet from Groovy's source code:
```groovy
    private Object getPropertyTryThese(String property, Object firstTry, Object secondTry) {
        try {
            // let's try getting the property on the first object
            return InvokerHelper.getProperty(firstTry, property);

        } catch (MissingPropertyException | MissingFieldException e1) {
            if (secondTry != null && firstTry != this && firstTry != secondTry) {
                try {
                    // let's try getting the property on the second object
                    return InvokerHelper.getProperty(secondTry, property);
                } catch (GroovyRuntimeException e2) {
                    // ignore, we'll throw e1
                }
            }
            throw e1;

        }
    }
```
https://github.com/apache/groovy/blob/02d1a3b4f76f1311eb2286188b224cfbbf0324db/src/main/java/groovy/lang/Closure.java#L322

In our case delegate is a `Map` and property retrieval for a `Map` is implemented as a call to `get` method on that `Map` as shown on following code snippet from Groovy implementation:
```groovy
if (isMap && !isStatic) {
	return ((Map<?,?>) object).get(name);
}	
```
https://github.com/apache/groovy/blob/master/src/main/java/groovy/lang/MetaClassImpl.java#L2001	


The problem here is that `Map` returns `null` when the property is not found however Closure expects `MissingPropertyException` or `MissingFieldException` exceptions to try to get the property from the owner. 


### Proposed fix
Create a wrapper that first checks if the property is defined in a map and if not then it tries to get property from the owner which in this case is an instance of GenericPipelineDeclaration.


PS. I'm not a Groovy developer so possibly a better solution could be found.

