### PR TITLE
feat(DockerMock): calls should show up in the call stack

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -309,6 +309,7 @@ abstract class BasePipelineTest {
     }
 
     void setVariables() {
+
         binding.setVariable('currentBuild', [
             absoluteUrl: 'http://example.com/dummy',
             buildVariables: [:],
@@ -331,7 +332,13 @@ abstract class BasePipelineTest {
             timeInMillis: 1,
             upstreamBuilds: [],
         ])
+
+        // Initialize interceptors for DockerMock
+        InterceptingGCL.interceptClassMethods(DockerMock.metaClass, helper, binding)
+        InterceptingGCL.interceptClassMethods(DockerMock.Container.metaClass, helper, binding)
+        InterceptingGCL.interceptClassMethods(DockerMock.Image.metaClass, helper, binding)
         binding.setVariable('docker', new DockerMock())
+
         binding.setVariable('env', [:])
         binding.setVariable('scm', [:])
     }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/TestDockerMock.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/TestDockerMock.groovy
@@ -13,16 +13,105 @@ import org.junit.Test
  */
 class DockerMockTest extends BasePipelineTest {
   Object script = null
+  String testImage = 'test'
 
   @Before
   @Override
   void setUp() {
     super.setUp()
-    this.script = loadScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
+    script = loadScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
   }
 
   @Test
-  void executePipeline() throws Exception {
-    script.execute()
+  void verifyDockerBuild() throws Exception {
+    script.test_docker_build(testImage)
+    printCallStack()
+    assertCallStackContains('DockerMock.build(test')
+  }
+
+  @Test
+  void verifyDockerBuildTwoArgs() throws Exception {
+    script.test_docker_build_two_args(testImage)
+    printCallStack()
+    assertCallStackContains('DockerMock.build(test, --build_arg arg1=val1 --build_arg arg2=val2)')
+  }
+
+  @Test
+  void verifyWithServer() throws Exception {
+    script.test_with_server(testImage)
+    printCallStack()
+    assertCallStackContains('DockerMock.withServer(test.server, fake-credentials, groovy.lang.Closure)')
+    assertCallStackContains('Hello from withServer')
+  }
+
+  @Test
+  void verifyWithTool() throws Exception {
+    script.test_with_tool(testImage)
+    runScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
+    printCallStack()
+    assertCallStackContains('DockerMock.withTool(test-docker, groovy.lang.Closure)')
+    assertCallStackContains('Hello from withTool')
+  }
+
+  @Test
+  void verifyWithRegistry() throws Exception {
+    script.test_with_registry(testImage)
+    printCallStack()
+    assertCallStackContains('DockerMock.withRegistry(test.registry, fake-credentials, groovy.lang.Closure)')
+    assertCallStackContains('Hello from withRegistry')
+  }
+
+  @Test
+  void verifyInside() throws Exception {
+    script.test_inside(testImage)
+    printCallStack()
+    assertCallStackContains('Image.inside(groovy.lang.Closure)')
+    assertCallStackContains('Hello from inside')
+  }
+
+  @Test
+  void verifyWithRun() throws Exception {
+    runScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
+    script.test_image_with_run(testImage)
+    printCallStack()
+    assertCallStackContains('Image.withRun(groovy.lang.Closure)')
+    assertCallStackContains('Hello from withRun')
+  }
+
+  @Test
+  void verifyImageName() throws Exception {
+    script.test_image_name(testImage)
+    printCallStack()
+    assertCallStackContains('Image.imageName()')
+  }
+
+  @Test
+  void verifyImagePull() throws Exception {
+    script.test_image_pull(testImage)
+    runScript('src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile')
+    printCallStack()
+    assertCallStackContains('Image.pull()')
+  }
+
+  @Test
+  void verifyImagePush() throws Exception {
+    script.test_image_push(testImage)
+    printCallStack()
+    assertCallStackContains('Image.push(test-tag)')
+  }
+
+  @Test
+  void verifyImageRun() throws Exception {
+    script.test_image_run(testImage)
+    printCallStack()
+    assertCallStackContains('Image.run()')
+    assertCallStackContains('Container.stop()')
+  }
+
+  @Test
+  void verifyImageTag() throws Exception {
+    script.test_image_tag(testImage)
+    printCallStack()
+    assertCallStackContains('Image.tag(test)')
   }
 }

--- a/src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Docker_Jenkinsfile
@@ -1,76 +1,107 @@
-void execute() {
-  node {
-    String testImageName = 'test'
 
-    stage('Test docker.build()') {
-      def image = docker.build(testImageName)
+def test_docker_build(testImageName) {
+  stage('Test docker.build()') {
+    def image = docker.build(testImageName)
+    assert image.id == testImageName
+  }
+}
+
+def test_docker_build_two_args(testImageName) {
+  stage('Test docker.build() two args') {
+    def image = docker.build(testImageName, '--build_arg arg1=val1 --build_arg arg2=val2' )
+    assert image.id == testImageName
+  }
+}
+
+def test_docker_image(testImageName) {
+  stage('Test docker.image()') {
+    def image = docker.image(testImageName)
+    assert image.id == testImageName
+  }
+}
+
+def test_with_registry(testImageName) {
+  stage('Test docker.withRegistry') {
+    docker.withRegistry('test.registry', 'fake-credentials') {
+      def image = docker.image(testImageName)
+      echo "Hello from withRegistry ${image.id}"
       assert image.id == testImageName
     }
+  }
+}
 
-    stage('Test docker.image()') {
+def test_with_server(testImageName) {
+  stage('Test docker.withServer()') {
+    docker.withServer('test.server', 'fake-credentials') {
       def image = docker.image(testImageName)
+      echo "Hello from withServer ${image.id}"
       assert image.id == testImageName
     }
+  }
+}
 
-    stage('Test docker.withRegistry') {
-      docker.withRegistry('test.registry', 'fake-credentials') {
-        def image = docker.image(testImageName)
-        assert image.id == testImageName
-      }
-    }
-
-    stage('Test docker.withServer()') {
-      docker.withServer('test.server', 'fake-credentials') {
-        def image = docker.image(testImageName)
-        assert image.id == testImageName
-      }
-    }
-
-    stage('Test docker.withTool()') {
-      docker.withTool('test-docker') {
-        def image = docker.image(testImageName)
-        assert image.id == testImageName
-      }
-    }
-
-    stage('Test docker.image.imageName()') {
+def test_with_tool(testImageName) {
+  stage('Test docker.withTool()') {
+    docker.withTool('test-docker') {
       def image = docker.image(testImageName)
-      assert image.imageName() == testImageName
+      echo "Hello from withTool ${image.id}"
+      assert image.id == testImageName
     }
+  }
+}
 
-    stage('Test docker.image.inside()') {
-      def image = docker.image(testImageName)
-      image.inside {
-        assert image.id == testImageName
-      }
+def test_image_name(testImageName) {
+  stage('Test docker.image.imageName()') {
+    def image = docker.image(testImageName)
+    assert image.imageName() == testImageName
+  }
+}
+
+def test_inside(testImageName) {
+  stage('Test docker.image.inside()') {
+    def image = docker.image(testImageName)
+    image.inside {
+      echo "Hello from inside ${image.id}"
+      assert image.id == testImageName
     }
+  }
+}
 
-    stage('Test docker.image.pull()') {
-      docker.image(testImageName).pull()
-    }
+def test_image_pull(testImageName) {
+  stage('Test docker.image.pull()') {
+    docker.image(testImageName).pull()
+  }
+}
 
-    stage('Test docker.image.push()') {
-      def image = docker.image(testImageName)
-      image.push('test-tag')
-      assert image.tagname == 'test-tag'
-    }
+def test_image_push(testImageName) {
+  stage('Test docker.image.push()') {
+    def image = docker.image(testImageName)
+    image.push('test-tag')
+    assert image.tagname == 'test-tag'
+  }
+}
 
-    stage('Test docker.image.run()') {
-      def container = docker.image(testImageName).run()
-      container.stop()
-    }
+def test_image_run(testImageName){
+  stage('Test docker.image.run()') {
+    def container = docker.image(testImageName).run()
+    container.stop()
+  }
+}
 
-    stage('Test docker.image.tag()') {
-      def image = docker.image(testImageName)
-      image.tag('test')
-      assert image.tagname == 'test'
-    }
+def test_image_tag(testImageName) {
+  stage('Test docker.image.tag()') {
+    def image = docker.image(testImageName)
+    image.tag('test')
+    assert image.tagname == 'test'
+  }
+}
 
-    stage('Test docker.image.withRun()') {
-      def image = docker.image(testImageName)
-      image.withRun {
-        assert image.id == testImageName
-      }
+def test_image_with_run(testImageName) {
+  stage('Test docker.image.withRun()') {
+    def image = docker.image(testImageName)
+    image.withRun {
+      echo "Hello from withRun ${image.id}"
+      assert image.id == testImageName
     }
   }
 }


### PR DESCRIPTION
Refactored Docker Mock tests. Setup Interceptors to trace docker mock methods in the call stack.

Fixes #406 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
