### PR TITLE
Don't use a single type in `MockScriptHandler` constructor

### DIFF
--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -367,7 +367,7 @@ class PipelineTestHelperTest {
     void runShWithDefaultHandler() {
         // given:
         helper.addShMock('command', 'ignored', 0)
-        helper.addShMock(null, 'default', 1)
+        helper.addShMock('default', 1)
         helper.addShMock('pwd', 'ignored', 2)
 
         // when:

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -289,6 +289,32 @@ class PipelineTestHelperTest {
     }
 
     @Test()
+    void runShWithPatternStatus() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock(~/echo\s(.*)/, 'mock-output', 777)
+
+        // when:
+        def status = helper.runSh(returnStatus: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo(777)
+    }
+
+    @Test()
+    void runShWithPatternStdout() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock(~/echo\s(.*)/, 'mock-output', 0)
+
+        // when:
+        def status = helper.runSh(returnStdout: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo('mock-output')
+    }
+
+    @Test()
     void runShWithDefaultPattern() {
         // given:
         helper.addShMock(~/.*/) { String script, String ...args ->


### PR DESCRIPTION
Instead of trying to squeeze three values in one `Object` type, this change introduces more constructor overrides for the `MockScriptHandler` class.

Note that this will be an API-breaking change that we'll need to document when released.

Fixes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/536.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
