### PR TITLE
Make params map immutable

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -341,7 +341,7 @@ abstract class BasePipelineTest {
 
         binding.setVariable('env', [:])
         binding.setVariable('scm', [:])
-        binding.setVariable('params', [:])
+        binding.setVariable('params', [:].asImmutable())
     }
 
     /**
@@ -507,9 +507,12 @@ abstract class BasePipelineTest {
      * Helper for adding a params value in tests
      */
     void addParam(String name, Object val, Boolean overWrite = false) {
-        Map params = binding.getVariable('params') as Map
-        if (params[name] == null || overWrite) {
-            params[name] = val
+        Map immutableParams = binding.getVariable('params') as Map
+        if (immutableParams[name] == null || overWrite) {
+            Map mutableParams = [:]
+            immutableParams.each { k, v -> mutableParams[k] = v }
+            mutableParams[name] = val
+            binding.setVariable('params', mutableParams.asImmutable())
         }
     }
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -341,6 +341,7 @@ abstract class BasePipelineTest {
 
         binding.setVariable('env', [:])
         binding.setVariable('scm', [:])
+        binding.setVariable('params', [:])
     }
 
     /**
@@ -506,10 +507,6 @@ abstract class BasePipelineTest {
      * Helper for adding a params value in tests
      */
     void addParam(String name, Object val, Boolean overWrite = false) {
-        if (!binding.hasVariable('params')) {
-            binding.setVariable('params', [:])
-        }
-
         Map params = binding.getVariable('params') as Map
         if (params[name] == null || overWrite) {
             params[name] = val

--- a/src/test/groovy/com/lesfurets/jenkins/TestAddParam.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestAddParam.groovy
@@ -10,4 +10,21 @@ class TestAddParam extends BasePipelineTest {
         super.setUp()
         addParam('FOO', 'BAR')
     }
+
+    @Test(expected = UnsupportedOperationException)
+    void addParamImmutable() throws Exception {
+        super.setUp()
+        addParam('FOO', 'BAR')
+
+        // We should not be able to modify existing parameters. This would not work on Jenkins.
+        binding.getVariable('params')['FOO'] = 'NOT-BAR'
+    }
+
+    @Test(expected = UnsupportedOperationException)
+    void addNewParamImmutable() throws Exception {
+        super.setUp()
+
+        // It also is not permitted to add new parameters directly. Instead, addParam must be used.
+        binding.getVariable('params')['BAZ'] = 'QUX'
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The params map is also immutable on a real Jenkins instance, so code
shouldn't be allowed to modify it directly here, either.

Fixes https://github.com/jenkinsci/JenkinsPipelineUnit/issues/528.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
