### PR TITLE
Improvements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ built-in Jenkins commands, job configurations, see the stacktrace of the whole e
 and even track regressions.
 
 # Table of Contents
+
 1. [Usage](#usage)
 1. [Configuration](#configuration)
 1. [Declarative Pipeline](#declarative-pipeline)
@@ -30,9 +31,12 @@ and even track regressions.
 ## Usage
 
 ### Add to your project as test dependency
+
 **Note:** Starting from version `1.2`, artifacts are published to
 `https://repo.jenkins-ci.org/releases`.
+
 Maven:
+
 ```xml
     <repositories>
         <repository>
@@ -54,6 +58,7 @@ Maven:
 ```
 
 Gradle:
+
 ```groovy
 repositories {
   maven { url 'https://repo.jenkins-ci.org/releases/' }
@@ -288,6 +293,7 @@ void debianBuildUnstable() {
 Note that in all cases, the `script` executed by `sh` must *exactly* match the string
 passed to `helper.addShMock`, including the script arguments, whitespace, etc. For more
 flexible matching, you can use a pattern (regular expression) and even capture groups:
+
 ```groovy
 helper.addShMock(~/.\/build.sh\s--(.*)/) { String script, String arg ->
     assert (arg == 'debug') || (arg == 'release')
@@ -297,6 +303,7 @@ helper.addShMock(~/.\/build.sh\s--(.*)/) { String script, String arg ->
 
 Also, mocks are stacked, so if two mocks match a call, the last one wins. Combined with a
 match-everything mock, you can tighten your tests a bit:
+
 ```groovy
 @Before
 void setUp() throws Exception {
@@ -331,9 +338,10 @@ void should_execute_without_errors() throws Exception {
 
 This will check as well `mvn verify` has been called during the job execution.
 
-
 ### Check Pipeline status
+
 Let's say you have a simple script and you'd like to check it behaviour if a step is failing
+
 ```groovy
 // Jenkinsfile
 // ...
@@ -346,6 +354,7 @@ node() {
 You can mock the `sh` step to just update the pipeline status to `FAILURE`. To verify that
 your pipeline is failing, you need to check the status with
 `BasePipelineTest.assertJobStatusFailure()`.
+
 ```groovy
 class TestCase extends BasePipelineTest {
   @Test
@@ -362,12 +371,13 @@ class TestCase extends BasePipelineTest {
 }
 ```
 
-
 ### Check Pipeline exceptions
+
 Sometimes it is useful to verify exactly that exception is thrown during the pipeline run.
 For example by one of your `SharedLib` module
 
 To do so you can use `org.junit.rules.ExpectedException`
+
 ```groovy
 import org.junit.Rule
 import org.junit.rules.ExpectedException
@@ -377,6 +387,7 @@ public ExpectedException thrown = ExpectedException.none();
 ```
 
 Here is a simple example to verify exception type and the message:
+
 ```groovy
 import org.junit.Rule
 import org.junit.rules.ExpectedException
@@ -413,6 +424,7 @@ running your tests: `-Dpipeline.stack.write=true`. You then can go ahead and com
 change in your SCM to check in the change.
 
 ### Preserve Original Callstack Argument References
+
 The default behavior of the callstack capture is to clone each call's arguments to
 preserve their values at time of the call should those arguments mutate downstream. That
 is a good guard when your scripts are passing ordinary mutable variables as arguments.
@@ -421,7 +433,6 @@ However, argument types that are not `Cloneable` are captured as `String` values
 the time this is a perfect fallback. But for some complex types, or for types that don't
 implement `toString()`, it can be tricky or impossible to validate the call values in a
 test.
-
 
 Take the following simple example.
 
@@ -524,7 +535,9 @@ This will work fine for such a project structure:
          └── groovy
              └── TestExampleJob.groovy
 ```
+
 ## Declarative Pipeline
+
 To test a declarative pipeline, you'll need to subclass the `DeclarativePipelineTest`
 class instead of `BasePipelineTest`
 
@@ -565,6 +578,7 @@ class TestExampleDeclarativeJob extends DeclarativePipelineTest {
 ```
 
 ### DeclarativePipelineTest
+
 The DeclarativePipelineTest class extends `BasePipelineTest`, so you can verify your
 declarative job the same way as scripted pipelines.
 
@@ -656,11 +670,14 @@ libraryJob.run()
         libraryJob.libraryResource(net/courtanet/jenkins/request.json)
         libraryJob.sh(curl -H 'Content-Type: application/json' -X POST -d '{"name" : "Ben"}' http://acme.com)
 ```
+
 ### Library Source Retrievers
+
 There are a few types of `SourceRetriever` implementations in addition to the previously
 described `GitSource` one.
 
 #### ProjectSource Retriever
+
 The `ProjectSource` retriever is useful if you write tests for the library itself. So it
 lets you to load the library files directly from the project root folder (where the `src`
 and `vars` folders are located).
@@ -679,6 +696,7 @@ Then you can use `projectSource` to point to the location of the library files. 
 `projectSource()` with no arguments will look for files in the project root. With
 `.defaultVersion('<notNeeded>')`,  you can load it in pipelines using `commons@master` or
 `commons@features` which would use the same repository.
+
 ```groovy
     // TestCase file
     // you need to import static method
@@ -703,6 +721,7 @@ Then you can use `projectSource` to point to the location of the library files. 
 ```
 
 #### LocalSource Retriever
+
 The `LocalSource` retriever is useful if you want to verify how well your library
 integrates with the pipelines. For example you may use pre-copied library files with
 different versions.
@@ -737,10 +756,12 @@ $ tree -L 1 /var/tmp/commons@master
 ```
 
 ### Loading library dynamically
+
 There is partial support for loading dynamic libraries. It doesn't implement all the
 features, but it could be useful sometimes.
 
 Pipeline example:
+
 ```
 def lib = library 'commons'
 
@@ -753,6 +774,7 @@ def utils = net.courtanet.jenkins.Utils.new()
 ```
 
 Test class example:
+
 ```groovy
     String clonePath = 'path/to/clone'
 
@@ -781,6 +803,7 @@ Test class example:
 ```
 
 ### Library global variables accepting library class instances as arguments: troubleshooting
+
 You might have a library defining global variables that implement custom steps
 accepting library class instances as arguments. For example consider the
 following library class and global variable.
@@ -806,6 +829,7 @@ void call(Monster1 m1) {
 ```
 
 Your pipeline uses both as follows.
+
 ```groovy
 vampire = new Monster1("Dracula")
 monster1(vampire)
@@ -977,6 +1001,7 @@ development cycle. It addresses some of the requirements traced in
 contribute please don't hesitate to discuss in issues and open a pull-request.
 
 ## Demos and Examples
+
 | URL | Frameworks and Tools | Test Subject | Test Layers |
 |-----|----------------------|--------------|-------------|
 | https://github.com/macg33zr/pipelineUnit | Spock, Gradle(Groovy)  | Jenkinsfile, scripted pipeline, SharedLibrary | UnitTest |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jenkins Pipeline Unit testing framework
+# `JenkinsPipelineUnit` Testing Framework
 
 Jenkins Pipeline Unit is a testing framework for unit testing Jenkins pipelines, written
 in [Groovy Pipeline DSL](https://jenkins.io/doc/book/pipeline/).
@@ -21,8 +21,8 @@ and even track regressions.
 
 1. [Usage](#usage)
 1. [Configuration](#configuration)
-1. [Declarative Pipeline](#declarative-pipeline)
-1. [Testing Shared Libraries](#testing-shared-libraries)
+1. [Declarative Pipeline](#declarative-pipelines)
+1. [Testing Shared Libraries](#testing-pipelines-that-use-shared-libraries)
 1. [Writing Testable Libraries](#writing-testable-libraries)
 1. [Note On CPS](#note-on-cps)
 1. [Contributing](#contributing)
@@ -30,7 +30,7 @@ and even track regressions.
 
 ## Usage
 
-### Add to your project as test dependency
+### Add to Your Project as Test Dependency
 
 JenkinsPipelineUnit requires Java 11, since this is also the minimum version required by
 Jenkins.
@@ -74,7 +74,7 @@ dependencies {
 }
 ```
 
-### Start writing tests
+### Start Writing Tests
 
 You can write your tests in Groovy or Java, using the test framework you prefer. The
 easiest entry point is extending the abstract class `BasePipelineTest`, which initializes
@@ -149,7 +149,7 @@ This test will print the call stack of the execution :
                   exampleJob.sh(mvn verify -DgitRevision=bcc19744)
 ```
 
-### Mock Jenkins variables
+### Mocking Jenkins Variables
 
 You can define both environment variables and job execution parameters.
 
@@ -168,7 +168,7 @@ You can define both environment variables and job execution parameters.
 The test helper already provides basic variables such as a very simple `currentBuild`
 definition. You can redefine them as you wish.
 
-### Mock Jenkins commands
+### Mocking Jenkins Commands
 
 You can register interceptors to mock pipeline methods, including Jenkins commands, which
 may or may not return a result.
@@ -201,7 +201,7 @@ Please refer to the `BasePipelineTest` class for the list of currently supported
 Some tricky methods such as `load` and `parallel` are implemented directly in the helper.
 If you want to override those, make sure that you extend the `PipelineTestHelper` class.
 
-### Mocking readFile and fileExists
+### Mocking `readFile` and `fileExists`
 
 The `readFile` and `fileExists` steps can be mocked to return a specific result for a
 given file name. This can be useful for testing pipelines for which file operations can
@@ -320,7 +320,7 @@ void setUp() throws Exception {
 }
 ```
 
-### Analyze the mock execution
+### Analyzing the Mock Execution
 
 The helper registers every method call to provide a stacktrace of the mock execution.
 
@@ -341,7 +341,7 @@ void should_execute_without_errors() throws Exception {
 
 This will check as well `mvn verify` has been called during the job execution.
 
-### Check Pipeline status
+### Checking Pipeline Status
 
 Let's say you have a simple script and you'd like to check it behaviour if a step is failing
 
@@ -374,7 +374,7 @@ class TestCase extends BasePipelineTest {
 }
 ```
 
-### Check Pipeline exceptions
+### Checking Pipeline Exceptions
 
 Sometimes it is useful to verify exactly that exception is thrown during the pipeline run.
 For example by one of your `SharedLib` module
@@ -407,7 +407,7 @@ class TestCase extends BasePipelineTest {
 }
 ```
 
-### Compare the callstacks with a previous implementation
+### Compare the Callstack with a Previous Implementation
 
 One other use of the callstacks is to check your pipeline executions for possible
 regressions. You have a dedicated method you can call if you extend `BaseRegressionTest`:
@@ -468,7 +468,7 @@ the variable in the callstack by setting this switch in your test setup:
        helper.cloneArgsOnMethodCallRegistration = false
 ```
 
-### Run script inline
+### Running Inline Scripts
 
 In case you want to have some script executed directly within a test case rather than
 creating a resource file for it, `loadInlineScript` and `runInlineScript` can be used.
@@ -539,7 +539,7 @@ This will work fine for such a project structure:
              └── TestExampleJob.groovy
 ```
 
-## Declarative Pipeline
+## Declarative Pipelines
 
 To test a declarative pipeline, you'll need to subclass the `DeclarativePipelineTest`
 class instead of `BasePipelineTest`
@@ -585,7 +585,7 @@ class TestExampleDeclarativeJob extends DeclarativePipelineTest {
 The DeclarativePipelineTest class extends `BasePipelineTest`, so you can verify your
 declarative job the same way as scripted pipelines.
 
-## Testing Shared Libraries
+## Testing Pipelines That Use Shared Libraries
 
 With [Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/), Jenkins
 lets you share common code from pipelines across different repositories. Shared libraries
@@ -758,7 +758,7 @@ $ tree -L 1 /var/tmp/commons@master
 └── vars
 ```
 
-### Loading library dynamically
+### Loading Libraries Dynamically
 
 There is partial support for loading dynamic libraries. It doesn't implement all the
 features, but it could be useful sometimes.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ and even track regressions.
 
 ### Add to your project as test dependency
 
+JenkinsPipelineUnit requires Java 11, since this is also the minimum version required by
+Jenkins.
+
 **Note:** Starting from version `1.2`, artifacts are published to
 `https://repo.jenkins-ci.org/releases`.
 

--- a/README.md
+++ b/README.md
@@ -694,16 +694,6 @@ The `ProjectSource` retriever is useful if you write tests for the library itsel
 lets you load the library files directly from the project root folder (where the `src`
 and `vars` folders are located).
 
-```
-$ tree -L 1 .
-.
-├── resources
-├── src
-└── vars
-└── test
-└── build.gradle
-```
-
 Then you can use `projectSource` to point to the location of the library files. Calling
 `projectSource()` with no arguments will look for files in the project root. With
 `.defaultVersion('<notNeeded>')`,  you can load it in pipelines using `commons@master` or
@@ -757,13 +747,6 @@ class TestCase extends BasePipelineTest {
 
 In the above example, the retriever would assume that the library files are located at
 `/var/tmp/commons@master`.
-```
-$ tree -L 1 /var/tmp/commons@master
-/var/tmp/commons@master
-├── resources
-├── src
-└── vars
-```
 
 ### Loading Libraries Dynamically
 

--- a/README.md
+++ b/README.md
@@ -38,34 +38,34 @@ Jenkins.
 **Note:** Starting from version `1.2`, artifacts are published to
 `https://repo.jenkins-ci.org/releases`.
 
-Maven:
+#### Maven
 
 ```xml
-    <repositories>
-        <repository>
-        <id>jenkins-ci-releases</id>
-        <url>https://repo.jenkins-ci.org/releases/</url>
-        </repository>
-        ...
-    </repositories>
+<repositories>
+    <repository>
+    <id>jenkins-ci-releases</id>
+    <url>https://repo.jenkins-ci.org/releases/</url>
+    </repository>
+    ...
+</repositories>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.lesfurets</groupId>
-            <artifactId>jenkins-pipeline-unit</artifactId>
-            <version>1.9</version>
-            <scope>test</scope>
-        </dependency>
-        ...
-    </dependencies>
+<dependencies>
+    <dependency>
+        <groupId>com.lesfurets</groupId>
+        <artifactId>jenkins-pipeline-unit</artifactId>
+        <version>1.9</version>
+        <scope>test</scope>
+    </dependency>
+    ...
+</dependencies>
 ```
 
-Gradle:
+#### Gradle
 
 ```groovy
 repositories {
-  maven { url 'https://repo.jenkins-ci.org/releases/' }
-  ...
+    maven { url 'https://repo.jenkins-ci.org/releases/' }
+    ...
 }
 
 dependencies {

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Jenkins Pipeline Unit testing framework
 
-Jenkins Pipeline Unit is a testing framework for unit testing Jenkins pipelines, written in
-[Groovy Pipeline DSL](https://jenkins.io/doc/book/pipeline/).
+Jenkins Pipeline Unit is a testing framework for unit testing Jenkins pipelines, written
+in [Groovy Pipeline DSL](https://jenkins.io/doc/book/pipeline/).
 
 [![Linux/Windows Build status](https://ci.jenkins.io/job/jenkinsci-libraries/job/JenkinsPipelineUnit/job/master/badge/icon)](https://ci.jenkins.io/blue/organizations/jenkins/jenkinsci-libraries%2FJenkinsPipelineUnit/activity?branch=master)
 [![Mac Build status](https://github.com/jenkinsci/JenkinsPipelineUnit/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/jenkinsci/JenkinsPipelineUnit/actions?query=event%3Apush+branch%3Amaster)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jenkinsci/JenkinsPipelineUnit?label=changelog)](https://github.com/jenkinsci/JenkinsPipelineUnit/releases)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/JenkinsPipelineUnit)
 
-If you use Jenkins as your CI workhorse (like us @ [lesfurets.com](https://www.lesfurets.com)) and you enjoy writing _pipeline-as-code_,
-you already know that pipeline code is very powerful but can get pretty complex.
+If you use Jenkins as your CI workhorse (like us @
+[lesfurets.com](https://www.lesfurets.com)) and you enjoy writing _pipeline-as-code_, you
+already know that pipeline code is very powerful but can get pretty complex.
 
-This testing framework lets you write unit tests on the configuration and conditional logic of the pipeline code, by providing a mock execution of the pipeline.
-You can mock built-in Jenkins commands, job configurations, see the stacktrace of the whole execution and even track regressions.
+This testing framework lets you write unit tests on the configuration and conditional
+logic of the pipeline code, by providing a mock execution of the pipeline. You can mock
+built-in Jenkins commands, job configurations, see the stacktrace of the whole execution
+and even track regressions.
 
 # Table of Contents
 1. [Usage](#usage)
@@ -27,7 +30,8 @@ You can mock built-in Jenkins commands, job configurations, see the stacktrace o
 ## Usage
 
 ### Add to your project as test dependency
-**Note:** Starting from `1.2` artifacts are published to `https://repo.jenkins-ci.org/releases`
+**Note:** Starting from version `1.2`, artifacts are published to
+`https://repo.jenkins-ci.org/releases`.
 Maven:
 ```xml
     <repositories>
@@ -64,8 +68,9 @@ dependencies {
 
 ### Start writing tests
 
-You can write your tests in Groovy or Java 8, using the test framework you prefer.
-The easiest entry point is extending the abstract class `BasePipelineTest`, which initializes the framework with JUnit.
+You can write your tests in Groovy or Java, using the test framework you prefer. The
+easiest entry point is extending the abstract class `BasePipelineTest`, which initializes
+the framework with JUnit.
 
 Let's say you wrote this awesome pipeline script, which builds and tests your project :
 
@@ -152,12 +157,13 @@ You can define both environment variables and job execution parameters.
     }
 ```
 
-The test helper already provides basic variables such as a very simple currentBuild definition.
-You can redefine them as you wish.
+The test helper already provides basic variables such as a very simple `currentBuild`
+definition. You can redefine them as you wish.
 
 ### Mock Jenkins commands
 
-You can register interceptors to mock pipeline methods, including Jenkins commands, which may or may not return a result.
+You can register interceptors to mock pipeline methods, including Jenkins commands, which
+may or may not return a result.
 
 ```groovy
     @Override
@@ -176,21 +182,22 @@ You can register interceptors to mock pipeline methods, including Jenkins comman
     }
 ```
 
-The test helper already includes some mocks, but the list is far from complete.
-You need to _register allowed methods_ if you want to override these mocks and add others.
-Note that you need to provide a method signature and a callback (closure or lambda) in order to allow a method.
-Any method call which is not recognized will throw an exception.
+The test helper already includes mocks for all base pipeline steps as well as a steps from
+a few widely-used plugins. You need to _register allowed methods_ if you want to override
+these mocks and add others. Note that you need to provide a method signature and a
+callback (closure or lambda) in order to allow a method. Any method call which is not
+recognized will throw an exception.
 
-You can take a look at the `BasePipelineTest` class to have the short list of allowed methods.
+Please refer to the `BasePipelineTest` class for the list of currently supported mocks.
 
 Some tricky methods such as `load` and `parallel` are implemented directly in the helper.
 If you want to override those, make sure that you extend the `PipelineTestHelper` class.
 
 ### Mocking readFile and fileExists
 
-The `readFile` and `fileExists` steps can be mocked to return a specific result for a given file name. This can be
-useful for testing pipelines for which file operations can influence subsequent steps. An example of such a testing
-scenario follows:
+The `readFile` and `fileExists` steps can be mocked to return a specific result for a
+given file name. This can be useful for testing pipelines for which file operations can
+influence subsequent steps. An example of such a testing scenario follows:
 
 ```groovy
 // Jenkinsfile
@@ -278,9 +285,9 @@ void debianBuildUnstable() {
 }
 ```
 
-Note that in all cases, the `script` executed by `sh` must *exactly* match the string passed to `helper.addShMock`,
-including the script arguments, whitespace etc.
-For less strict matching, you can use a pattern (regular expression) and even capture groups:
+Note that in all cases, the `script` executed by `sh` must *exactly* match the string
+passed to `helper.addShMock`, including the script arguments, whitespace, etc. For more
+flexible matching, you can use a pattern (regular expression) and even capture groups:
 ```groovy
 helper.addShMock(~/.\/build.sh\s--(.*)/) { String script, String arg ->
     assert (arg == 'debug') || (arg == 'release')
@@ -288,8 +295,8 @@ helper.addShMock(~/.\/build.sh\s--(.*)/) { String script, String arg ->
 }
 ```
 
-Also, mocks are stacked, so if two mocks match a call, the last one counts.
-Combined with a match-everything mock, you can tighten your tests a bit:
+Also, mocks are stacked, so if two mocks match a call, the last one wins. Combined with a
+match-everything mock, you can tighten your tests a bit:
 ```groovy
 @Before
 void setUp() throws Exception {
@@ -336,8 +343,9 @@ node() {
 }
 ```
 
-You can mock `sh` step to just update the pipeline status to `FAILURE`.
-To verify your pipeline is failing you need to check the status with `BasePipelineTest.assertJobStatusFailure()`
+You can mock the `sh` step to just update the pipeline status to `FAILURE`. To verify that
+your pipeline is failing, you need to check the status with
+`BasePipelineTest.assertJobStatusFailure()`.
 ```groovy
 class TestCase extends BasePipelineTest {
   @Test
@@ -387,8 +395,8 @@ class TestCase extends BasePipelineTest {
 
 ### Compare the callstacks with a previous implementation
 
-One other use of the callstacks is to check your pipeline executions for possible regressions.
-You have a dedicated method you can call if you extend `BaseRegressionTest`:
+One other use of the callstacks is to check your pipeline executions for possible
+regressions. You have a dedicated method you can call if you extend `BaseRegressionTest`:
 
 ```groovy
     @Test
@@ -399,21 +407,21 @@ You have a dedicated method you can call if you extend `BaseRegressionTest`:
     }
 ```
 
-This will compare the current callstack of the job to the one you have in a text callstack reference file.
-To update this file with new callstack, just set this JVM argument when running your tests: `-Dpipeline.stack.write=true`
+This will compare the current callstack of the job to the one you have in a text callstack
+reference file. To update this file with new callstack, just set this JVM argument when
+running your tests: `-Dpipeline.stack.write=true`. You then can go ahead and commit this
+change in your SCM to check in the change.
 
-You then can go ahead and commit this change in your SCM to check in the change.
+### Preserve Original Callstack Argument References
+The default behavior of the callstack capture is to clone each call's arguments to
+preserve their values at time of the call should those arguments mutate downstream. That
+is a good guard when your scripts are passing ordinary mutable variables as arguments.
 
-### Preserve original callstack argument references
-The default behavior of the callstack capture is to clone each call's arguments
-to preserve their values at time of the call should those arguments mutate
-downstream. That is a good guard when your scripts are passing ordinary mutable
-variables as arguments.
+However, argument types that are not `Cloneable` are captured as `String` values. Most of
+the time this is a perfect fallback. But for some complex types, or for types that don't
+implement `toString()`, it can be tricky or impossible to validate the call values in a
+test.
 
-However, argument types that are not `Cloneable` are captured as `String`
-values. Most of the time this is a perfect fallback. But for some complex
-types, or for types that don't implement `toString()`, it can be tricky
-or impossible to validate the call values in a test.
 
 Take the following simple example.
 
@@ -430,19 +438,17 @@ node() {
 }
 ```
 
-`pretendArgsFromFarUpstream` is a type of uncloneable map and will be recorded
-as a `String` in the callstack. Your test may want to perform fine grained
-validations via map key referencing instead of pattern matching or similar
-parsing. For example,
+`pretendArgsFromFarUpstream` is an immutable map and will be recorded as a `String` in the
+callstack. Your test may want to perform fine grained validations via map key referencing
+instead of pattern matching or similar parsing. For example:
 
 ```groovy
 assertEquals(arg.aNestedMap.bb, 2)
 ```
 
-If you want to perform this kind of validation--particularly if your pipelines
-pass `final` and/or immutable variables as arguments--you can retain the
-direct reference to the variable in the callstack by setting this switch
-in your test setup.
+You may want to perform this kind of validation, particularly if your pipelines pass
+`final` and/or immutable variables as arguments. You can retain the direct reference to
+the variable in the callstack by setting this switch in your test setup:
 
 ```groovy
        helper.cloneArgsOnMethodCallRegistration = false
@@ -450,8 +456,8 @@ in your test setup.
 
 ### Run script inline
 
-In case you want to have some script executed directly within a test case rather
-than creating a resource file for it, `loadInlineScript` and `runInlineScript` can be used.
+In case you want to have some script executed directly within a test case rather than
+creating a resource file for it, `loadInlineScript` and `runInlineScript` can be used.
 
 ```groovy
     @Test
@@ -471,18 +477,20 @@ than creating a resource file for it, `loadInlineScript` and `runInlineScript` c
     }
 ```
 
-Note that inline scripts cannot be debugged via breakpoints as there is no backing files to attach to!
+Note that inline scripts cannot be debugged via breakpoints as there is no file to attach
+to!
 
 ## Configuration
 
 The abstract class `BasePipelineTest` configures the helper with useful conventions:
 
-- It looks for pipeline scripts in your project in root (`./.`) and `src/main/jenkins` paths.
+- It looks for pipeline scripts in your project in root (`./.`) and `src/main/jenkins`
+  paths.
 - Jenkins pipelines let you load other scripts from a parent script with `load` command.
-However `load` takes the full path relative to the project root.
-The test helper mock successfully the `load` command to load the scripts.
-To make relative paths work, you need to configure the path of the project where your pipeline scripts are,
-which defaults to `.`.
+  However `load` takes the full path relative to the project root. The test helper mock
+  successfully the `load` command to load the scripts. To make relative paths work, you
+  need to configure the path of the project where your pipeline scripts are, which
+  defaults to `.`.
 - Pipeline script extension, which defaults to jenkins (matches any `*.jenkins` file)
 
 Overriding these default values is easy:
@@ -517,8 +525,8 @@ This will work fine for such a project structure:
              └── TestExampleJob.groovy
 ```
 ## Declarative Pipeline
-There is an experimental support of declarative pipeline in `1.3`
-To try this feature you need to use `DeclarativePipelineTest` class instead of `BasePipelineTest`
+To test a declarative pipeline, you'll need to subclass the `DeclarativePipelineTest`
+class instead of `BasePipelineTest`
 
 ```groovy
 // Jenkinsfile
@@ -557,19 +565,19 @@ class TestExampleDeclarativeJob extends DeclarativePipelineTest {
 ```
 
 ### DeclarativePipelineTest
-It extends `BasePipelineTest` functionality so you can verify your declarative job the same way
-like it was a scripted pipeline
+The DeclarativePipelineTest class extends `BasePipelineTest`, so you can verify your
+declarative job the same way as scripted pipelines.
 
 ## Testing Shared Libraries
 
-With [Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/) Jenkins lets you share common code
-on pipelines across different repositories of your organization.
-Shared libraries are configured via a settings interface in Jenkins and imported
-with `@Library` annotation in your scripts.
+With [Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/), Jenkins
+lets you share common code from pipelines across different repositories. Shared libraries
+are configured in the Jenkins settings and imported with `@Library` annotation or the
+`library` step.
 
-Testing pipeline scripts using external libraries is not trivial because the shared library code
-is checked in another repository.
-JenkinsPipelineUnit lets you test shared libraries and pipelines depending on these libraries.
+Testing pipeline scripts using external libraries is not trivial because the shared
+library code is another repository. JenkinsPipelineUnit lets you test shared libraries and
+pipelines that depend on these libraries.
 
 Here is an example pipeline using a shared library:
 
@@ -594,8 +602,7 @@ node() {
 }
 ```
 
-This pipeline is using a shared library called `commons`.
-Now let's test it:
+This pipeline is using a shared library called `commons`. Now let's test it:
 
 ```groovy
 // You need to import the class first
@@ -617,20 +624,22 @@ import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
     printCallStack()
 ```
 
-Notice how we defined the shared library and registered it to the helper.
-Library definition is done via a fluent API which lets you set the same configurations as in
-[Jenkins Global Pipeline Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries).
+Notice how the shared library is defined and registered to the helper. The library
+definition is done via a fluent API which lets you set the same configurations as in
+[Jenkins Global Pipeline
+Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries).
 
-The `retriever` and `targetPath` fields tell the framework how to fetch the sources of the library, in which local path.
-The framework comes with two naive but useful retrievers, `gitSource` and `localSource`.
-You can write your own retriever by implementing the `SourceRetriever` interface.
+The `retriever` and `targetPath` fields tell the framework how to fetch the sources of the
+library, and to which local path. The framework comes with two naive but useful
+retrievers, `gitSource` and `localSource`. You can write your own retriever by
+implementing the `SourceRetriever` interface.
 
 Note that properties `defaultVersion`, `allowOverride` and `implicit` are optional with
 default values `master`, `true` and `false`.
 
-Now if we execute this test, the framework will fetch the sources from the Git repository and
-load classes, scripts, global variables and resources found in the library.
-The callstack of this execution will look like the following:
+Now if we execute this test, the framework will fetch the sources from the Git repository
+and load classes, scripts, global variables and resources found in the library. The
+callstack of this execution will look like the following:
 
 ```text
 Loading shared library commons with version master
@@ -648,12 +657,13 @@ libraryJob.run()
         libraryJob.sh(curl -H 'Content-Type: application/json' -X POST -d '{"name" : "Ben"}' http://acme.com)
 ```
 ### Library Source Retrievers
-There are a few types of `SourceRetriever` implementation in addition to previously
-discribed `GitSource` you can use for different applications
+There are a few types of `SourceRetriever` implementations in addition to the previously
+described `GitSource` one.
 
 #### ProjectSource Retriever
-`ProjectSource` retriever is useful if you write tests for the library itself.
-So it lets you to load the library files directly from project root folder (where `src`, `vars`, ... are loacted)
+The `ProjectSource` retriever is useful if you write tests for the library itself. So it
+lets you to load the library files directly from the project root folder (where the `src`
+and `vars` folders are located).
 
 ```
 $ tree -L 1 .
@@ -665,10 +675,10 @@ $ tree -L 1 .
 └── build.gradle
 ```
 
-Then you need you can use `projectSource` to point library files location
-* `projectSource()` with no args looking for files in project root
-* `.defaultVersion('<notNeeded>')` means you can load it in pipelines
-   using `commons@master` or `commons@features` which would use the same code base
+Then you can use `projectSource` to point to the location of the library files. Calling
+`projectSource()` with no arguments will look for files in the project root. With
+`.defaultVersion('<notNeeded>')`,  you can load it in pipelines using `commons@master` or
+`commons@features` which would use the same repository.
 ```groovy
     // TestCase file
     // you need to import static method
@@ -693,8 +703,9 @@ Then you need you can use `projectSource` to point library files location
 ```
 
 #### LocalSource Retriever
-`LocalSource` retriever is useful if you want to verify how well your library integrates
-with the pipelines. For example you may use pre-copied library files of different versions.
+The `LocalSource` retriever is useful if you want to verify how well your library
+integrates with the pipelines. For example you may use pre-copied library files with
+different versions.
 
 ```groovy
     import static com.lesfurets.jenkins.unit.global.lib.LocalSource.localSource
@@ -715,8 +726,8 @@ with the pipelines. For example you may use pre-copied library files of differen
         ...
 ```
 
-The retriever assumes that library files are located at
-`/var/tmp/commons@master` folder
+In the above example, the retriever would assume that the library files are located at
+`/var/tmp/commons@master`.
 ```
 $ tree -L 1 /var/tmp/commons@master
 /var/tmp/commons@master
@@ -726,8 +737,8 @@ $ tree -L 1 /var/tmp/commons@master
 ```
 
 ### Loading library dynamically
-There is a partial support of dynamic library loading.
-It does't implement all the features, however sometimes it could be useful.
+There is partial support for loading dynamic libraries. It doesn't implement all the
+features, but it could be useful sometimes.
 
 Pipeline example:
 ```
@@ -802,20 +813,18 @@ monster1(vampire)
 //Expect "Dracula is always very scary"
 ```
 
-If this does not yield the expected output but instead throws a
-`MissingMethodException` with the cause `No signature of method:
-JENKINSFILE.monster1() is applicable for argument types: (org.test.Monster1)
-values: [org.test.Monster1@45f50182]` you may need to disable library class
-preload in your testing. You can do so in your test setup via the following
-switch.
+If this does not yield the expected output but instead throws a `MissingMethodException`
+with the cause `No signature of method: Jenkinsfile.monster() is applicable for argument
+types: (org.test.Monster) values: [com.example.Monster1@d34db33f]` you may need to disable
+library class preloading in your test setup, which you do with the following switch.
 
 ```groovy
 helper.libLoader.preloadLibraryClasses = false
 ```
 
-You may need to do this for on a test-by-test basis as disabling class preload
-can cause problems in other use cases. For example, when you have library
-classes that require access to the `env` global.
+You may need to do this on a test-by-test basis, as disabling class preloading can cause
+problems in other cases. For example, when you have library classes that require access to
+the `env` global.
 
 ## Writing Testable Libraries
 
@@ -833,9 +842,9 @@ We recommend the following best-practices for organizing pipeline code:
 ### On External Scripts
 
 In general, it's better to avoid having complex build logic inside of build pipelines.
-Although tools like JenkinsPipelineUnit are useful in testing pipelines, it's much easier
-to run build scripts locally (meaning, outside of a Jenkins environment). Languages like
-Python have much more sophisticated linting and testing tools than Groovy does.
+Although tools like `JenkinsPipelineUnit` are useful in testing pipelines, it's much
+easier to run build scripts locally (meaning, outside of a Jenkins environment). Languages
+like Python have much more sophisticated linting and testing tools than Groovy does.
 
 That said, [CodeNarc](https://codenarc.org/) can be used to lint Groovy code, including
 `Jenkinsfile` files.
@@ -854,7 +863,8 @@ has several advantages:
 #### Example Pipeline Library Organization
 
 Let's say we have a library responsible for a very complex operation, in this case, adding
-two numbers together. 😄 Here's what that library (let's call it `HardMath`) might look like:
+two numbers together. 😄 Here's what that library (let's call it `HardMath`) might look
+like:
 
 In `src/com/example/HardMath.groovy`
 
@@ -938,29 +948,33 @@ with JenkinsPipelineUnit, have a look at
 
 ## Note on CPS
 
-If you already fiddled with Jenkins pipeline DSL, you experienced strange errors during execution on Jenkins.
-This is because Jenkins does not directly execute your pipeline in Groovy,
-but transforms the pipeline code into an intermediate format in order to run Groovy code in
-[Continuation Passing Style](https://en.wikipedia.org/wiki/Continuation-passing_style) (CPS).
+If you already fiddled with Jenkins pipeline DSL, you may have experienced strange errors
+during execution on Jenkins. This is because Jenkins does not directly execute your
+pipeline in Groovy, but transforms the pipeline code into an intermediate format in order
+to run Groovy code in [Continuation Passing
+Style](https://en.wikipedia.org/wiki/Continuation-passing_style) (CPS).
 
-The usual errors are partly due to the
-[the sandboxing Jenkins applies](https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin#ScriptSecurityPlugin-GroovySandboxing)
-for security reasons, and partly due to the
-[serializability Jenkins imposes](https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md#serializing-local-variables).
+The usual errors are partly due to the [the sandboxing Jenkins
+applies](https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin#ScriptSecurityPlugin-GroovySandboxing)
+for security reasons, and partly due to the [serializability Jenkins
+imposes](https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md#serializing-local-variables).
 
-Jenkins requires that at each execution step, the whole script context is serializable, in order to stop and resume the job execution.
-To simulate this aspect, CPS versions of the helpers transform your scripts into the CPS format and check if at each step your script context is serializable.
+Jenkins requires that at each execution step, the whole script context is serializable, in
+order to stop and resume the job execution. To simulate this aspect, CPS versions of the
+helpers transform your scripts into the CPS format and check if at each step your script
+context is serializable.
 
-To use this _*experimental*_ feature, you can use the abstract class `BasePipelineTestCPS` instead of `BasePipelineTest`.
-You may see some changes in the call stacks that the helper registers.
-Note also that the serialization used to test is not the same as what Jenkins uses.
-You may find some incoherence in that level.
+To use this _*experimental*_ feature, you can use the abstract class `BasePipelineTestCPS`
+instead of `BasePipelineTest`. You may see some changes in the callstacks that the helper
+registers. Note also that the serialization used to test is not the same as what Jenkins
+uses. You may find some incoherence in that respect.
 
 ## Contributing
 
-JenkinsPipelineUnit aims to help devops code and test Jenkins pipelines with a shorter development cycle.
-It addresses some of the requirements traced in [JENKINS-33925](https://issues.jenkins-ci.org/browse/JENKINS-33925).
-If you are willing to contribute please don't hesitate to discuss in issues and open a pull-request.
+JenkinsPipelineUnit aims to help developers code and test Jenkins pipelines with a shorter
+development cycle. It addresses some of the requirements traced in
+[JENKINS-33925](https://issues.jenkins-ci.org/browse/JENKINS-33925). If you are willing to
+contribute please don't hesitate to discuss in issues and open a pull-request.
 
 ## Demos and Examples
 | URL | Frameworks and Tools | Test Subject | Test Layers |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can write your tests in Groovy or Java, using the test framework you prefer.
 easiest entry point is extending the abstract class `BasePipelineTest`, which initializes
 the framework with JUnit.
 
-Let's say you wrote this awesome pipeline script, which builds and tests your project :
+Let's say you wrote this awesome pipeline script, which builds and tests your project:
 
 ```groovy
 def execute() {
@@ -109,7 +109,7 @@ def execute() {
 return this
 ```
 
-Now using the Jenkins Pipeline Unit you can unit test if it does the job :
+Now using the Jenkins Pipeline Unit you can write a unit test to see if it does the job:
 
 ```groovy
 import com.lesfurets.jenkins.unit.BasePipelineTest
@@ -123,7 +123,7 @@ class TestExampleJob extends BasePipelineTest {
 }
 ```
 
-This test will print the call stack of the execution :
+This test will print the call stack of the execution, which should look like so:
 
 ```text
    exampleJob.run()
@@ -239,8 +239,8 @@ They can be mocked to either (a) statically return:
 - A string for standard output
 - A return code
 
-..., or (b) execute a closure that returns a `Map` (with `stdout` and `exitValue` entries).
-The closure will be executed when the shell is called, allowing for dynamic behaviour.
+Or (b), to execute a closure that returns a `Map` (with `stdout` and `exitValue` entries).
+The closure will be executed when the shell is called, allowing for dynamic behavior.
 
 Here is a sample pipeline and corresponding unit tests for each of these variants.
 
@@ -343,11 +343,11 @@ void shouldExecuteWithoutErrors() {
 }
 ```
 
-This will check as well `mvn verify` has been called during the job execution.
+This will also check that `mvn verify` was called during the job execution.
 
 ### Checking Pipeline Status
 
-Let's say you have a simple script and you'd like to check it behaviour if a step is failing
+Let's say you have a simple script, and you'd like to check its behavior if a step fails.
 
 ```groovy
 // Jenkinsfile
@@ -444,7 +444,7 @@ the time this is a perfect fallback. But for some complex types, or for types th
 implement `toString()`, it can be tricky or impossible to validate the call values in a
 test.
 
-Take the following simple example.
+Take the following simple example:
 
 ```groovy
 Map pretendArgsFromFarUpstream = [
@@ -460,7 +460,7 @@ node() {
 ```
 
 `pretendArgsFromFarUpstream` is an immutable map and will be recorded as a `String` in the
-callstack. Your test may want to perform fine grained validations via map key referencing
+callstack. Your test may want to perform fine-grained validations via map key referencing
 instead of pattern matching or similar parsing. For example:
 
 ```groovy
@@ -691,7 +691,7 @@ described `GitSource` one.
 #### ProjectSource Retriever
 
 The `ProjectSource` retriever is useful if you write tests for the library itself. So it
-lets you to load the library files directly from the project root folder (where the `src`
+lets you load the library files directly from the project root folder (where the `src`
 and `vars` folders are located).
 
 ```


### PR DESCRIPTION
Inspired by the discussion in https://github.com/jenkinsci/JenkinsPipelineUnit/issues/549#issuecomment-1209503564. This PR fixes the README to be use a more consistent style and tone, specifically by:

- Use 90-character lines
- en_US spelling/grammar/punctuation rules
- Fix Groovy example code to be more "CodeNarc-friendly"
- Update examples for JUnit 5
- Add information about Java requirements

---

This PR is open to the community to review; I would appreciate all input and suggestions. Assuming there are no dissenting reviews, I will merge this PR in 2 weeks on 8 Sept 2022.