### PR TITLE
Allow declaration of kubernetes agent with no config

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -55,6 +55,10 @@ class AgentDeclaration extends GenericPipelineDeclaration {
         this.docker = createComponent(DockerAgentDeclaration, closure)
     }
 
+    def kubernetes(boolean _) {
+        kubernetes([:])
+    }
+
     def kubernetes(Object kubernetesAgent) {
         this.@kubernetes = kubernetesAgent as KubernetesAgentDeclaration
     }

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -639,6 +639,13 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void should_kubernetes_default_agent() throws Exception {
+        runScript('Kubernetes_Default_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Executing on agent [kubernetes')
+        assertJobStatusSuccess()
+    }
+
     @Test void should_credentials() throws Exception {
         addCredential('my-prefined-secret-text', 'something_secret')
         runScript('Credentials_Jenkinsfile')

--- a/src/test/jenkins/jenkinsfiles/Kubernetes_Default_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Kubernetes_Default_Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent { kubernetes true }
+    stages {
+        stage('Example Test') {
+            steps {
+                echo 'Hello, JDK'
+                sh 'java -version'
+            }
+        }
+    }
+}


### PR DESCRIPTION
The kubernetes agent declaration supports using default/unspecified pod (similar to "agent any") by passing true instead of specifying any details. The pipeline syntax generator even provides this when you do not set any options for it.

However, since AgentDeclaration's interface accepts an Object and tries to cast it to a KubernetesAgentDeclaration, attempting to test a pipeline using this syntax fails with a casting error since Boolean cannot be cast to KubernetesAgentDeclaration. Therefore, add a specialization of the method that accepts Boolean and creates an empty KubernetesAgentDeclaration.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
