### PR TITLE
Require Java 11 for Gradle build, remove Spring framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 buildPluginWithGradle(
    configurations: [
-      [platform: 'linux', jdk: '8'],
       [platform: 'linux', jdk: '11'],
       [platform: 'windows', jdk: '11'],
    ],

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ repositories {
 group = "com.lesfurets"
 archivesBaseName = "jenkins-pipeline-unit"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 dependencies {
     implementation('org.codehaus.groovy:groovy-all:2.4.14')

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation('org.apache.ivy:ivy:2.5.1')
     api('org.assertj:assertj-core:3.23.1')
     implementation('org.apache.commons:commons-lang3:3.12.0')
-    api('org.springframework:spring-core:5.3.23')
 
     testImplementation('junit:junit:4.13.2')
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] ~Link to relevant issues in GitHub or Jira~
- [X] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [X] ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~

---

We don't need the Spring framework anymore, the last traces of it were removed in 612ef94. Spring 6.x requires JDK 17, which is incompatible with our requirement for JDK 11 compatibility (since this is the minimum version required by Jenkins).