### PR TITLE
Allow for java 11 tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 dependencies {
-    implementation('org.codehaus.groovy:groovy-all:2.4.14')
+    implementation('org.codehaus.groovy:groovy-all:2.5.14')
     implementation('com.cloudbees:groovy-cps:1.31')
     implementation('commons-io:commons-io:2.11.0')
     implementation('org.apache.ivy:ivy:2.5.1')


### PR DESCRIPTION
Currently, used groovy version do not allow for java 11 builds.

```
[ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:2.1.0:generateTestStubs (groovy) on project jenkins-shared-library: Execution groovy of goal org.codehaus.gmavenplus:gmavenplus-plugin:2.1.0:generateTestStubs failed: Target bytecode 11 requires Groovy 2.5.3/3.0.0-alpha-4 or newer. No 2.6 version is supported. -> [Help 1]
```

```
[INFO] +- com.lesfurets:jenkins-pipeline-unit:jar:1.16:test
[INFO] |  +- org.assertj:assertj-core:jar:3.23.1:test
[INFO] |  |  \- net.bytebuddy:byte-buddy:jar:1.12.10:test
[INFO] |  +- org.springframework:spring-core:jar:5.3.22:test
[INFO] |  |  \- org.springframework:spring-jcl:jar:5.3.22:test
[INFO] |  +- org.codehaus.groovy:groovy-all:jar:2.4.14:test
[INFO] |  +- com.cloudbees:groovy-cps:jar:1.31:test
[INFO] |  +- commons-io:commons-io:jar:2.11.0:test
[INFO] |  +- org.apache.ivy:ivy:jar:2.5.0:test
[INFO] |  \- org.apache.commons:commons-lang3:jar:3.12.0:test
```

This PR bumps this version to the least version which is still acceptable and do not introduce breaking changes.
https://groovy-lang.org/releasenotes/groovy-2.5.html


- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
