### PR TITLE
Support dockerfile agent declaration with filename

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -1,7 +1,7 @@
 package com.lesfurets.jenkins.unit.declarative
 
 import com.lesfurets.jenkins.unit.declarative.agent.DockerAgentDeclaration
-import com.lesfurets.jenkins.unit.declarative.agent.DockerFileAgentDeclaration
+import com.lesfurets.jenkins.unit.declarative.agent.DockerfileAgentDeclaration
 import com.lesfurets.jenkins.unit.declarative.agent.KubernetesAgentDeclaration
 import groovy.transform.ToString
 
@@ -13,7 +13,7 @@ class AgentDeclaration extends GenericPipelineDeclaration {
     String label
     DockerAgentDeclaration docker
     KubernetesAgentDeclaration kubernetes
-    DockerFileAgentDeclaration dockerfileAgent
+    DockerfileAgentDeclaration dockerfileAgent
     String customWorkspace
     def binding = null
     String registryCredentialsId = null
@@ -56,11 +56,11 @@ class AgentDeclaration extends GenericPipelineDeclaration {
     }
 
     def dockerfile(Object dockerfile) {
-        this.@dockerfileAgent = dockerfile as DockerFileAgentDeclaration
+        this.@dockerfileAgent = dockerfile as DockerfileAgentDeclaration
     }
 
-    def dockerfile(@DelegatesTo(strategy = DELEGATE_FIRST, value = DockerFileAgentDeclaration) Closure closure) {
-        this.@dockerfileAgent = createComponent(DockerFileAgentDeclaration, closure)
+    def dockerfile(@DelegatesTo(strategy = DELEGATE_FIRST, value = DockerfileAgentDeclaration) Closure closure) {
+        this.@dockerfileAgent = createComponent(DockerfileAgentDeclaration, closure)
     }
 
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/AgentDeclaration.groovy
@@ -16,8 +16,6 @@ class AgentDeclaration extends GenericPipelineDeclaration {
     DockerfileAgentDeclaration dockerfileAgent
     String customWorkspace
     def binding = null
-    String registryCredentialsId = null
-    String registryUrl = null
 
     def label(String label) {
         this.label = label
@@ -74,14 +72,6 @@ class AgentDeclaration extends GenericPipelineDeclaration {
 
     def getParams() {
         return binding?.params
-    }
-
-    def registryCredentialsId(String registryCredentialsId) {
-        this.registryCredentialsId = registryCredentialsId
-    }
-
-    def registryUrl(String registryUrl) {
-        this.registryUrl = registryUrl
     }
 
     def execute(Object delegate) {

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerFileAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerFileAgentDeclaration.groovy
@@ -1,0 +1,55 @@
+package com.lesfurets.jenkins.unit.declarative.agent
+
+
+import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
+import groovy.transform.ToString
+
+@ToString(includePackage = false, includeNames = true, ignoreNulls = true)
+class DockerFileAgentDeclaration extends GenericPipelineDeclaration {
+    String additionalBuildArgs
+    String args
+    String customWorkspace
+    String dockerfileDir
+    String filename
+    String label
+    String registryCredentialsId
+    String registryUrl
+    Boolean reuseNode
+
+    def additionalBuildArgs(String additionalBuildArgs) {
+        this.additionalBuildArgs = additionalBuildArgs
+    }
+
+    def args(String args) {
+        this.args = args
+    }
+
+    def customWorkspace(final String customWorkspace) {
+        this.customWorkspace = customWorkspace
+    }
+
+    def dir(String dir) {
+        this.dockerfileDir = dir
+    }
+
+    def filename(String filename) {
+        this.filename = filename
+    }
+
+    def label(final String label) {
+        this.label = label
+    }
+
+    def registryCredentialsId(final String registryCredentialsId) {
+        this.registryCredentialsId = registryCredentialsId
+    }
+
+    def registryUrl(final String registryUrl) {
+        this.registryUrl = registryUrl
+    }
+
+    def reuseNode(boolean reuse) {
+        this.reuseNode = reuse
+    }
+
+}

--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerfileAgentDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/agent/DockerfileAgentDeclaration.groovy
@@ -5,7 +5,7 @@ import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import groovy.transform.ToString
 
 @ToString(includePackage = false, includeNames = true, ignoreNulls = true)
-class DockerFileAgentDeclaration extends GenericPipelineDeclaration {
+class DockerfileAgentDeclaration extends GenericPipelineDeclaration {
     String additionalBuildArgs
     String args
     String customWorkspace

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDockerAgentInStep.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDockerAgentInStep.groovy
@@ -28,13 +28,13 @@ class TestDockerAgentInStep extends DeclarativePipelineTest {
     @Test
     void test_dockerfile_agent_only_filename_specified() {
         runScript("Dockerfile_Agent_Only_Filename_JenkinsFile")
-        assertCallStack().contains('Executing on agent [dockerfile')
+        assertCallStackContains('Executing on agent [dockerfile')
         assertJobStatusSuccess()
     }
 
     @Test void test_dockerfile_default_agent() throws Exception {
         runScript('Dockerfile_Agent_Default_Jenkinsfile')
-        assertCallStack().contains('Executing on agent [dockerfile')
+        assertCallStackContains('Executing on agent [dockerfile')
         assertJobStatusSuccess()
     }
 

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDockerAgentInStep.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDockerAgentInStep.groovy
@@ -26,10 +26,23 @@ class TestDockerAgentInStep extends DeclarativePipelineTest {
     }
 
     @Test
-    void test_dockerfile_agent_callstack_does_not_contain_binding() {
+    void test_dockerfile_agent_only_filename_specified() {
+        runScript("Dockerfile_Agent_Only_Filename_JenkinsFile")
+        assertCallStack().contains('Executing on agent [dockerfile')
+        assertJobStatusSuccess()
+    }
+
+    @Test void test_dockerfile_default_agent() throws Exception {
+        runScript('Dockerfile_Agent_Default_Jenkinsfile')
+        assertCallStack().contains('Executing on agent [dockerfile')
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_docker_agent_callstack_does_not_contain_binding() {
         runScript("Docker_agentInStep_JenkinsFile")
         assertJobStatusSuccess()
         assertCallStack().doesNotContain('binding:groovy.lang.Binding@')
-        assertCallStack().contains('Docker_agentInStep_JenkinsFile.echo(Executing on agent [docker:[image:maven, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:latest]])')
+        assertCallStackContains('Docker_agentInStep_JenkinsFile.echo(Executing on agent [docker:[image:maven, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:latest]])')
     }
 }

--- a/src/test/jenkins/jenkinsfiles/Dockerfile_Agent_Default_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Dockerfile_Agent_Default_Jenkinsfile
@@ -1,0 +1,9 @@
+pipeline {
+    stages {
+        stage('Build') {
+            agent {
+                dockerfile true
+            }
+        }
+    }
+}

--- a/src/test/jenkins/jenkinsfiles/Dockerfile_Agent_Only_Filename_JenkinsFile
+++ b/src/test/jenkins/jenkinsfiles/Dockerfile_Agent_Only_Filename_JenkinsFile
@@ -1,0 +1,11 @@
+pipeline {
+    stages {
+        stage('Build') {
+            agent {
+                dockerfile {
+                    filename 'Dockerfile'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I came across a limitation, the library does not support a jenkinsfile I am using even though it is completely valid and works fine on Jenkins. I've created this pull request to address this limitation so that I could continue the journey with this library. I am basically a newbie to groovy (just implemented a few jenkinsfiles in it so far) so open to any suggestions. I followed the pattern used for `KubernetesAgentDeclaration` and moved `DockerfileAgentDeclaration` in a dedicated class.

An example jenkinsfile which should be supported:
```
pipeline {
    stages {
        stage('Build') {
            agent {
                dockerfile {
                    filename 'Dockerfile'
                }
            }
        }
    }
}
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
