### PR TITLE
BasePipelineTest: Add result to default mock of `build`

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -137,6 +137,7 @@ abstract class BasePipelineTest {
                 getDescription:{"Dummy build description"},
                 getFullProjectName:{"some_dir/some_job"},
                 getProjectName:{"some_job"},
+                getResult:{"SUCCESS"},
             ]
         })
         helper.registerAllowedMethod('booleanParam', [Map], paramInterceptor)


### PR DESCRIPTION
Running tests of pipeline scripts that trigger other builds, the build result always ends up being `FAILURE`.

This PR adds `SUCCESS` as default result of triggered builds, which seems reasonable and in the spirit of other mocks such as for `sh`.

I am not aware of any issue tickets that relate to this.
Please advise if any tests are needed for this change.

### Testing done

`BasePipelineTest` has not detailed unit tests.

We've been having this change in use for years via a fork of the library.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
