### PR TITLE
Update groovy-cps from 1.31 to 3722.v85ce2a_c6240b_

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ plugins {
 }
 
 repositories {
-  mavenCentral()
+    mavenCentral()
+    maven { url 'https://repo.jenkins-ci.org/public/' }
 }
 
 group = "com.lesfurets"
@@ -21,7 +22,8 @@ targetCompatibility = 11
 
 dependencies {
     implementation('org.codehaus.groovy:groovy-all:2.4.21')
-    implementation('com.cloudbees:groovy-cps:1.31')
+    implementation('com.cloudbees:groovy-cps:3722.v85ce2a_c6240b_')
+    testImplementation('io.jenkins.plugins:pipeline-groovy-lib:656.va_a_ceeb_6ffb_f7')
     implementation('commons-io:commons-io:2.13.0')
     implementation('org.apache.ivy:ivy:2.5.1')
     api('org.assertj:assertj-core:3.24.2')


### PR DESCRIPTION
The original groovy-cps maintained at https://github.com/cloudbees/groovy-cps has been archived and merged with the workflow-cps-plugin as module.

The change proposed reflects this merge and allows consuming maintained and up-to-date versions of groovy-cps.