### PR TITLE
Keep track of wrapper updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: 11
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Run Tests
         run: ./gradlew --no-daemon cleanTest build

--- a/.github/workflows/update-gradle-wrapper.yaml
+++ b/.github/workflows/update-gradle-wrapper.yaml
@@ -1,0 +1,18 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
I was looking forward to updating the wrapper to support Java 20, but given it's a sensitive component, I chose to add an action doing that automatically, and validating its integrity.