### PR TITLE
Add match-all addShMock invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ class TestExampleJob extends BasePipelineTest {
 }
 ```
 
-After calling `super.setUp()`, the test `helper` instance is available, as well as many 
-helper methods. The test helper already provides basic variables such as a very simple 
+After calling `super.setUp()`, the test `helper` instance is available, as well as many
+helper methods. The test helper already provides basic variables such as a very simple
 `currentBuild` definition. You can redefine them as you wish.
 
 Note that `super.setUp()` must be called prior to using most features. This is commonly done
@@ -335,7 +335,7 @@ void setUp() {
     // - generate an error on unexpected calls
     // - ignore any echo (debug) outputs, they are not relevant
     // - all further shell mocks are configured in the test
-    helper.addShMock(null) { throw new Exception('Unexpected sh call') }
+    helper.addShMock() { throw new Exception('Unexpected sh call') }
     helper.addShMock(~/echo\s.*/, '', 0)
 }
 ```

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -72,6 +72,12 @@ class PipelineTestHelper {
             this.callback = callback
         }
 
+        MockScriptHandler(Closure callback) {
+            this.fullMatchFilter = null
+            this.regexpMatchFilter = null
+            this.callback = callback
+        }
+
         /**
          * match a script invocation against our filter
          */
@@ -793,7 +799,7 @@ class PipelineTestHelper {
     /**
      * Configure mock output for the `sh` command. This function should be called before
      * attempting to call `JenkinsMocks.sh()`.
-     * @param filter Script command to mock or null if any command is matched.
+     * @param filter Script command to mock
      * @param stdout Standard output text to return for the given command.
      * @param exitValue Exit value for the command.
      */
@@ -804,7 +810,7 @@ class PipelineTestHelper {
     /**
      * Configure mock output for the `sh` command. This function should be called before
      * attempting to call `JenkinsMocks.sh()`.
-     * @param filter Regexp pattern to mock or null if any command is matched.
+     * @param filter Regexp pattern to mock
      * @param stdout Standard output text to return for the given command.
      * @param exitValue Exit value for the command.
      */
@@ -815,7 +821,7 @@ class PipelineTestHelper {
     /**
      * Configure mock callback for the `sh` command. This function should be called before
      * attempting to call `JenkinsMocks.sh()`.
-     * @param filter Script command to mock or null if any command is matched.
+     * @param filter Script command to mock
      * @param callback Closure to be called when the mock is executed. This closure will be
      *                 passed the script call which is being executed, and
      *                 <strong>must</strong> return a {@code Map} with the following
@@ -832,7 +838,7 @@ class PipelineTestHelper {
     /**
      * Configure mock callback for the `sh` command. This function should be called before
      * attempting to call `JenkinsMocks.sh()`.
-     * @param filter Regexp pattern to mock or null if any command is matched.
+     * @param filter Regexp pattern to mock
      * @param callback Closure to be called when the mock is executed. This closure will be
      *                 passed the script call which is being executed, and
      *                 <strong>must</strong> return a {@code Map} with the following
@@ -846,6 +852,22 @@ class PipelineTestHelper {
         mockShHandlers << new MockScriptHandler(filter, callback)
     }
 
+    /**
+     * Configure match-all mock callback for the `sh` command. This function should be called
+     * before attempting to call `JenkinsMocks.sh()`.
+     * @param callback Closure to be called when the mock is executed. This closure will be
+     *                 passed the script call which is being executed, and
+     *                 <strong>must</strong> return a {@code Map} with the following
+     *                 key/value pairs:
+     *                 <ul>
+     *                   <li>{@code stdout}: {@code String} with the mocked output.</li>
+     *                   <li>{@code exitValue}: {@code int} with the mocked exit value.</li>
+     *                 </ul>
+     */
+    void addShMock(Closure callback) {
+        mockShHandlers << new MockScriptHandler(callback)
+    }
+
     @SuppressWarnings('ThrowException')
     def runSh(def args) {
         return runScript(args, mockShHandlers)
@@ -854,7 +876,7 @@ class PipelineTestHelper {
     /**
      * Configure mock output for the `bat` command. This function should be called before
      * attempting to call `JenkinsMocks.bat()`.
-     * @param filter Script command to mock or null if any command is matched.
+     * @param filter Script command to mock
      * @param stdout Standard output text to return for the given command.
      * @param exitValue Exit value for the command.
      */
@@ -865,7 +887,7 @@ class PipelineTestHelper {
     /**
      * Configure mock output for the `bat` command. This function should be called before
      * attempting to call `JenkinsMocks.bat()`.
-     * @param filter Regexp pattern to mock or null if any command is matched.
+     * @param filter Regexp pattern to mock
      * @param stdout Standard output text to return for the given command.
      * @param exitValue Exit value for the command.
      */
@@ -876,7 +898,7 @@ class PipelineTestHelper {
     /**
      * Configure mock callback for the `bat` command. This function should be called before
      * attempting to call `JenkinsMocks.bat()`.
-     * @param filter Script command to mock or null if any command is matched.
+     * @param filter Script command to mock
      * @param callback Closure to be called when the mock is executed. This closure will be
      *                 passed the script call which is being executed, and
      *                 <strong>must</strong> return a {@code Map} with the following
@@ -893,7 +915,7 @@ class PipelineTestHelper {
     /**
      * Configure mock callback for the `bat` command. This function should be called before
      * attempting to call `JenkinsMocks.bat()`.
-     * @param filter Regexp pattern to mock or null if any command is matched.
+     * @param filter Regexp pattern to mock
      * @param callback Closure to be called when the mock is executed. This closure will be
      *                 passed the script call which is being executed, and
      *                 <strong>must</strong> return a {@code Map} with the following
@@ -905,6 +927,22 @@ class PipelineTestHelper {
      */
     void addBatMock(Pattern filter, Closure callback) {
         mockBatHandlers << new MockScriptHandler(filter, callback)
+    }
+
+    /**
+     * Configure match-all mock callback for the `bat` command. This function should be called
+     * before attempting to call `JenkinsMocks.bat()`.
+     * @param callback Closure to be called when the mock is executed. This closure will be
+     *                 passed the script call which is being executed, and
+     *                 <strong>must</strong> return a {@code Map} with the following
+     *                 key/value pairs:
+     *                 <ul>
+     *                   <li>{@code stdout}: {@code String} with the mocked output.</li>
+     *                   <li>{@code exitValue}: {@code int} with the mocked exit value.</li>
+     *                 </ul>
+     */
+    void addBatMock(Closure callback) {
+        mockBatHandlers << new MockScriptHandler(callback)
     }
 
     @SuppressWarnings('ThrowException')

--- a/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/PipelineTestHelperTest.groovy
@@ -331,6 +331,56 @@ class PipelineTestHelperTest {
     }
 
     @Test()
+    void runShWithNoArgs() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock() { script ->
+            return [stdout: '', exitValue: 2]
+        }
+
+        // when:
+        def status = helper.runSh(returnStatus: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
+    @Test()
+    void runBatWithNoArgs() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addBatMock() { script ->
+            return [stdout: '', exitValue: 2]
+        }
+
+        // when:
+        def status = helper.runBat(returnStatus: true, script: 'echo foo')
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
+    @Test()
+    void runShWithNoArgsMultiline() {
+        // given:
+        def helper = new PipelineTestHelper()
+        helper.addShMock() { script ->
+            return [stdout: '', exitValue: 2]
+        }
+
+        // when:
+        def status = helper.runSh(returnStatus: true, script:
+            '''echo foo &&\
+            echo bar
+            '''
+        )
+
+        // then:
+        assertThat(status).isEqualTo(2)
+    }
+
+
+    @Test()
     void runShWithoutMockOutput() {
         // given:
 


### PR DESCRIPTION
The existing configuration for a match-everything sh mock uses `null` as the argument, which causes this error:

```console
groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method com.lesfurets.jenkins.unit.PipelineTestHelper#addShMock.
Cannot resolve which method to invoke for [null, class TestIsDatabricksRepo$_testNoDbxFolder_closure5] due to overlapping prototypes between:
	[class java.lang.String, class groovy.lang.Closure]
	[class java.util.regex.Pattern, class groovy.lang.Closure]
```

This can be resolved by using a pattern that matches everything (`~/(?s).*/`). We need the embedded DOTALL[0] flag, because otherwise multiline scripts like the following are not caught:

```groovy
    def status = sh(script: '''\
    echo hi
    ls -d .dbx
    '''.stripIndent(), returnStatus: true)
```

If there is a better way to do this, let me know! But for now, this fixes the docs bug of the docs suggesting an incorrect configuration.

[0]: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#DOTALL

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
