### PR TITLE
Added support for beforeAgent property in when statements

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/declarative/WhenDeclaration.groovy
@@ -21,6 +21,7 @@ class WhenDeclaration extends GenericPipelineDeclaration {
     Closure<Boolean> expression
     String envName
     String envValue
+    Boolean beforeAgent
 
     def allOf(@DelegatesTo(strategy = DELEGATE_FIRST, value = AllOfDeclaration) Closure closure) {
         this.allOf = createComponent(AllOfDeclaration, closure)
@@ -64,6 +65,10 @@ class WhenDeclaration extends GenericPipelineDeclaration {
         else {
             tag(args.pattern)
         }
+    }
+
+    def beforeAgent (Boolean arg) {
+        this.beforeAgent = arg
     }
 
     def buildingTag () {

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -419,6 +419,22 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         assertJobStatusSuccess()
     }
 
+    @Test void when_nested_when_beforeAgent_with_matching_branch_expression() throws Exception {
+        addEnvVar('BRANCH_NAME', 'main')
+        runScript('Nested_BeforeAgent_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Executing nested when beforeAgent expression')
+        assertJobStatusSuccess()
+    }
+
+    @Test void when_nested_when_beforeAgent_with_nonmatching_branch_expression() throws Exception {
+        addEnvVar('BRANCH_NAME', 'dev')
+        runScript('Nested_BeforeAgent_Jenkinsfile')
+        printCallStack()
+        assertCallStack().contains('Skipping stage Example nested when beforeAgent expression')
+        assertJobStatusSuccess()
+    }
+
     @Test void when_branch_using_explicit_equals_comparator() throws Exception {
         addEnvVar('BRANCH_NAME', 'develop')
         runScript('Branch_Jenkinsfile')

--- a/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/unit/declarative/TestDeclarativePipeline.groovy
@@ -424,6 +424,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         runScript('Nested_BeforeAgent_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('Executing nested when beforeAgent expression')
+        assertCallStack().contains('Executing on agent [label:beforeAgent-testLabel]')
         assertJobStatusSuccess()
     }
 
@@ -432,6 +433,7 @@ class TestDeclarativePipeline extends DeclarativePipelineTest {
         runScript('Nested_BeforeAgent_Jenkinsfile')
         printCallStack()
         assertCallStack().contains('Skipping stage Example nested when beforeAgent expression')
+        assertCallStack().doesNotContain('Executing on agent [label:beforeAgent-testLabel]')
         assertJobStatusSuccess()
     }
 

--- a/src/test/jenkins/jenkinsfiles/Nested_BeforeAgent_Jenkinsfile
+++ b/src/test/jenkins/jenkinsfiles/Nested_BeforeAgent_Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+    stages {
+        stage('Example Build') {
+            steps {
+                echo 'Hello World'
+            }
+        }
+        stage('Example nested when beforeAgent expression') {
+            agent {
+                label "beforeAgent-testLabel"
+            }
+            when {
+                beforeAgent true
+                branch 'main'
+            }
+            steps {
+                echo 'Executing nested when beforeAgent expression'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request addresses the missing support for `beforeAgent` inside `when` statements, see also issue https://github.com/jenkinsci/JenkinsPipelineUnit/issues/227.

### Testing done

I've added new test cases and a Jenkinsfile with a nested `beforeAgent` property inside a `when` statement to cover the use case that without this PR would lead to the error message mentioned in https://github.com/jenkinsci/JenkinsPipelineUnit/issues/227. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue