### PR TITLE
Add Script & Library Caching

### DIFF
--- a/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/BasePipelineTest.groovy
@@ -1,5 +1,7 @@
 package com.lesfurets.jenkins.unit
 
+import com.lesfurets.jenkins.unit.global.lib.LibraryLoader
+
 import static java.util.stream.Collectors.joining
 import static org.assertj.core.api.Assertions.assertThat
 

--- a/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/PipelineTestHelper.groovy
@@ -238,6 +238,10 @@ class PipelineTestHelper {
 
     Map<String, String> mockReadFileOutputs = [:]
 
+    private static final Map<String, Class> scriptClasses = [:]
+
+    private boolean shouldCacheScriptsAndLibraries = false
+
     /**
     * Get library loader object
     *
@@ -246,6 +250,18 @@ class PipelineTestHelper {
     */
     LibraryLoader getLibLoader() {
         return this.libLoader
+    }
+
+    PipelineTestHelper withShouldCacheScriptsAndLibraries(boolean shouldCacheScriptsAndLibraries) {
+        this.shouldCacheScriptsAndLibraries = shouldCacheScriptsAndLibraries
+        return this
+    }
+
+    /**
+     * Clears the cache of loaded script classes
+     */
+    static void clearScriptClasses() {
+        scriptClasses.clear()
     }
 
     /**
@@ -431,6 +447,11 @@ class PipelineTestHelper {
         LibraryAnnotationTransformer libraryTransformer = new LibraryAnnotationTransformer(libLoader)
         configuration.addCompilationCustomizers(libraryTransformer)
 
+        if (!shouldCacheScriptsAndLibraries) {
+            clearScriptClasses()
+            LibraryLoader.clearLibRecords()
+        }
+
         ImportCustomizer importCustomizer = new ImportCustomizer()
         imports.each { k, v -> importCustomizer.addImport(k, v) }
         configuration.addCompilationCustomizers(importCustomizer)
@@ -541,7 +562,11 @@ class PipelineTestHelper {
     Script loadScript(String scriptName, Binding binding) {
         Objects.requireNonNull(binding, "Binding cannot be null.")
         Objects.requireNonNull(gse, "GroovyScriptEngine is not initialized: Initialize the helper by calling init().")
-        Class scriptClass = gse.loadScriptByName(scriptName)
+        Class scriptClass = scriptClasses.get(scriptName)
+        if (scriptClass == null) {
+            scriptClass = gse.loadScriptByName(scriptName)
+            scriptClasses.put(scriptName, scriptClass)
+        }
         setGlobalVars(binding)
         Script script = InvokerHelper.createScript(scriptClass, binding)
         InterceptingGCL.interceptClassMethods(script.metaClass, this, binding)

--- a/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LibraryLoader.groovy
+++ b/src/main/groovy/com/lesfurets/jenkins/unit/global/lib/LibraryLoader.groovy
@@ -35,7 +35,7 @@ class LibraryLoader {
     //classes want to access the binding env.
     Boolean preloadLibraryClasses = true
 
-    final Map<String, LibraryRecord> libRecords = new HashMap<>()
+    static final Map<String, LibraryRecord> libRecords = new HashMap<>()
 
     LibraryLoader(GroovyClassLoader groovyClassLoader, Map<String, LibraryConfiguration> libraryDescriptions) {
         this.groovyClassLoader = groovyClassLoader
@@ -64,6 +64,13 @@ class LibraryLoader {
                 .forEach {
             doLoadLibrary(it)
         }
+    }
+
+    /**
+     * Clears the cache of lib records
+     */
+    static void clearLibRecords() {
+        libRecords.clear()
     }
 
     /**

--- a/src/test/groovy/com/lesfurets/jenkins/TestLibraryAndScriptCaching.groovy
+++ b/src/test/groovy/com/lesfurets/jenkins/TestLibraryAndScriptCaching.groovy
@@ -1,0 +1,71 @@
+package com.lesfurets.jenkins
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import com.lesfurets.jenkins.unit.global.lib.LibraryLoader
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotEquals
+
+class TestLibraryAndScriptCaching extends BasePipelineTest {
+
+    @Override
+    @BeforeEach
+    void setUp() throws Exception {
+        scriptRoots += 'src/test/jenkins'
+        super.setUp()
+    }
+
+    private final library = library().name('commons')
+            .defaultVersion('<notNeeded>')
+            .allowOverride(false)
+            .implicit(false)
+            .targetPath('<notNeeded>')
+            .retriever(projectSource(this.class.getResource('/libs/commons@master').getFile()))
+            .build()
+
+    @Test
+    void scriptCacheDisabled() {
+        def script1 = loadScript('job/exampleJob.jenkins')
+        helper.init()
+        def script2 = loadScript('job/exampleJob.jenkins')
+        assertNotEquals(script1.metaClass.theClass, script2.metaClass.theClass)
+    }
+
+    @Test
+    void scriptCacheEnabledDisabled() {
+        helper.withShouldCacheScriptsAndLibraries(true)
+        def script1 = loadScript('job/exampleJob.jenkins')
+        helper.init()
+        def script2 = loadScript('job/exampleJob.jenkins')
+        assertEquals(script1.metaClass.theClass, script2.metaClass.theClass)
+    }
+
+    @Test
+    void libraryCacheDisabled() {
+        helper.registerSharedLibrary(library)
+        helper.libLoader.loadLibrary(library.name)
+        def lib1 = LibraryLoader.libRecords.get("commons@<notNeeded>")
+        helper.init()
+        helper.registerSharedLibrary(library)
+        helper.libLoader.loadLibrary(library.name)
+        def lib2 = LibraryLoader.libRecords.get("commons@<notNeeded>")
+        assertNotEquals(lib1, lib2)
+    }
+
+    @Test
+    void libraryCacheEnabled() {
+        helper.withShouldCacheScriptsAndLibraries(true)
+        helper.registerSharedLibrary(library)
+        helper.libLoader.loadLibrary(library.name)
+        def lib1 = LibraryLoader.libRecords.get("commons@<notNeeded>")
+        helper.init()
+        helper.registerSharedLibrary(library)
+        helper.libLoader.loadLibrary(library.name)
+        def lib2 = LibraryLoader.libRecords.get("commons@<notNeeded>")
+        assertEquals(lib1, lib2)
+    }
+}


### PR DESCRIPTION
Added a script and library cache to the PipelineTestHelper, this helped reduce the time a suite of tests took on a complex pipeline library from several minutes to ~30 seconds, as each test previous took ~7 seconds to load the script and the library. Any changes to mocks or script/libraries during test execution would be ignored by the caching, so the cache is disabled by default with a flag to enable it.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
