### PR TITLE
Require Java 21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
       - master
 jobs:
   test:
-    name: macos-17
+    name: macos-21
     runs-on: macos-latest
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
+          distribution: temurin
           java-version: 17
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Tests
         run: ./gradlew --no-daemon cleanTest build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPluginWithGradle(
    configurations: [
-      [platform: 'linux', jdk: '17'],
-      [platform: 'windows', jdk: '17'],
+      [platform: 'linux', jdk: '21'],
+      [platform: 'windows', jdk: '21'],
    ],
 )

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and even track regressions.
 
 ### Add to Your Project as Test Dependency
 
-JenkinsPipelineUnit requires Java 17, since this is also the minimum version required by
+JenkinsPipelineUnit requires Java 21, since this is also the minimum version required by
 some library dependencies. Also note that JenkinsPipelineUnit is not currently compatible
 with Groovy 4, please see [this
 issue](https://github.com/jenkinsci/JenkinsPipelineUnit/issues/521) for more details.

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ base {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {


### PR DESCRIPTION
This is required as of [Jenkins 2.545](https://www.jenkins.io/changelog/#v2.545).