### PR TITLE
Fix error when publishing to Artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,9 @@ repositories {
 }
 
 group = "com.lesfurets"
+def archivesBaseName = "jenkins-pipeline-unit"
 base {
-    archivesName = "jenkins-pipeline-unit"
+    archivesName = archivesBaseName
 }
 
 java {
@@ -79,7 +80,7 @@ publishing {
             artifact tasks.sourcesJar
             artifact tasks.javadocJar
             pom {
-                artifactId = "$project.base.archivesName"
+                artifactId = archivesBaseName
                 packaging = 'jar'
                 description = 'Jenkins Pipeline Unit testing framework'
                 url = 'https://github.com/jenkinsci/JenkinsPipelineUnit'


### PR DESCRIPTION
This fixes the following error message:

> User <whoever> is not permitted to deploy 'com/lesfurets/extension
> 'base' property 'archivesName'/1.31/extension 'base' property
> 'archivesName'-1.31-javadoc.jar' into
> 'releases:com/lesfurets/extension 'base' property
> 'archivesName'/1.31/extension 'base' property
> 'archivesName'-1.31-javadoc.jar'.
